### PR TITLE
tests: add test coverage

### DIFF
--- a/chip_test.go
+++ b/chip_test.go
@@ -1,0 +1,259 @@
+package espflash
+
+import (
+	"testing"
+)
+
+func TestChipTypeString(t *testing.T) {
+	tests := []struct {
+		chip     ChipType
+		expected string
+	}{
+		{ChipESP8266, "ESP8266"},
+		{ChipESP32, "ESP32"},
+		{ChipESP32S2, "ESP32-S2"},
+		{ChipESP32S3, "ESP32-S3"},
+		{ChipESP32C2, "ESP32-C2"},
+		{ChipESP32C3, "ESP32-C3"},
+		{ChipESP32C6, "ESP32-C6"},
+		{ChipESP32H2, "ESP32-H2"},
+		{ChipAuto, "Auto"},
+		{ChipType(99), "Unknown(99)"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.expected, func(t *testing.T) {
+			got := tt.chip.String()
+			if got != tt.expected {
+				t.Errorf("ChipType(%d).String() = %q, want %q", int(tt.chip), got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestChipDefsCompleteness(t *testing.T) {
+	// Every chip type (except ChipAuto) should have a definition.
+	expectedChips := []ChipType{
+		ChipESP8266,
+		ChipESP32,
+		ChipESP32S2,
+		ChipESP32S3,
+		ChipESP32C2,
+		ChipESP32C3,
+		ChipESP32C6,
+		ChipESP32H2,
+	}
+
+	for _, ct := range expectedChips {
+		def, ok := chipDefs[ct]
+		if !ok {
+			t.Errorf("chipDefs missing definition for %s", ct)
+			continue
+		}
+		if def.ChipType != ct {
+			t.Errorf("chipDefs[%s].ChipType = %s, want %s", ct, def.ChipType, ct)
+		}
+		if def.Name == "" {
+			t.Errorf("chipDefs[%s].Name is empty", ct)
+		}
+		if def.FlashSizes == nil || len(def.FlashSizes) == 0 {
+			t.Errorf("chipDefs[%s].FlashSizes is empty", ct)
+		}
+		if def.FlashFrequency == nil || len(def.FlashFrequency) == 0 {
+			t.Errorf("chipDefs[%s].FlashFrequency is empty", ct)
+		}
+	}
+}
+
+func TestDetectChipByMagic(t *testing.T) {
+	tests := []struct {
+		name     string
+		magic    uint32
+		expected ChipType
+		found    bool
+	}{
+		{"ESP8266", 0xFFF0C101, ChipESP8266, true},
+		{"ESP32", 0x00F01D83, ChipESP32, true},
+		{"ESP32-S2", 0x000007C6, ChipESP32S2, true},
+		{"unknown magic", 0xDEADBEEF, 0, false},
+		{"zero magic", 0x00000000, 0, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			def := detectChipByMagic(tt.magic)
+			if tt.found {
+				if def == nil {
+					t.Fatalf("detectChipByMagic(0x%08X) = nil, want %s", tt.magic, tt.expected)
+				}
+				if def.ChipType != tt.expected {
+					t.Errorf("detectChipByMagic(0x%08X).ChipType = %s, want %s",
+						tt.magic, def.ChipType, tt.expected)
+				}
+			} else {
+				if def != nil {
+					t.Errorf("detectChipByMagic(0x%08X) = %s, want nil", tt.magic, def.ChipType)
+				}
+			}
+		})
+	}
+}
+
+func TestDefaultFlashSizes(t *testing.T) {
+	sizes := defaultFlashSizes()
+
+	expected := map[string]byte{
+		"1MB":   0x00,
+		"2MB":   0x10,
+		"4MB":   0x20,
+		"8MB":   0x30,
+		"16MB":  0x40,
+		"32MB":  0x50,
+		"64MB":  0x60,
+		"128MB": 0x70,
+	}
+
+	for name, val := range expected {
+		got, ok := sizes[name]
+		if !ok {
+			t.Errorf("defaultFlashSizes() missing %q", name)
+			continue
+		}
+		if got != val {
+			t.Errorf("defaultFlashSizes()[%q] = 0x%02X, want 0x%02X", name, got, val)
+		}
+	}
+}
+
+func TestDefaultFlashSizesUpperNibble(t *testing.T) {
+	// Flash size values should only occupy the upper nibble (bits 4-7).
+	sizes := defaultFlashSizes()
+	for name, val := range sizes {
+		if val&0x0F != 0 {
+			t.Errorf("defaultFlashSizes()[%q] = 0x%02X has non-zero lower nibble", name, val)
+		}
+	}
+}
+
+func TestESP8266FlashSizes(t *testing.T) {
+	// ESP8266 uses a different encoding than ESP32+.
+	sizes := defESP8266.FlashSizes
+	expected := map[string]byte{
+		"512KB": 0x00,
+		"256KB": 0x10,
+		"1MB":   0x20,
+		"2MB":   0x30,
+		"4MB":   0x40,
+	}
+	for name, val := range expected {
+		got, ok := sizes[name]
+		if !ok {
+			t.Errorf("ESP8266 FlashSizes missing %q", name)
+			continue
+		}
+		if got != val {
+			t.Errorf("ESP8266 FlashSizes[%q] = 0x%02X, want 0x%02X", name, got, val)
+		}
+	}
+}
+
+func TestChipCapabilities(t *testing.T) {
+	// ESP8266: no encrypted flash, no ROM compressed flash, no ROM change baud
+	if defESP8266.SupportsEncryptedFlash {
+		t.Error("ESP8266 should not support encrypted flash")
+	}
+	if defESP8266.ROMHasCompressedFlash {
+		t.Error("ESP8266 should not have ROM compressed flash")
+	}
+	if defESP8266.ROMHasChangeBaud {
+		t.Error("ESP8266 should not have ROM change baud")
+	}
+
+	// ESP32: no encrypted flash support, but has ROM compressed flash and change baud
+	if defESP32.SupportsEncryptedFlash {
+		t.Error("ESP32 should not support encrypted flash")
+	}
+	if !defESP32.ROMHasCompressedFlash {
+		t.Error("ESP32 should have ROM compressed flash")
+	}
+	if !defESP32.ROMHasChangeBaud {
+		t.Error("ESP32 should have ROM change baud")
+	}
+
+	// ESP32-S2 and newer: all capabilities
+	newerChips := []*chipDef{defESP32S2, defESP32S3, defESP32C2, defESP32C3, defESP32C6, defESP32H2}
+	for _, def := range newerChips {
+		if !def.SupportsEncryptedFlash {
+			t.Errorf("%s should support encrypted flash", def.Name)
+		}
+		if !def.ROMHasCompressedFlash {
+			t.Errorf("%s should have ROM compressed flash", def.Name)
+		}
+		if !def.ROMHasChangeBaud {
+			t.Errorf("%s should have ROM change baud", def.Name)
+		}
+	}
+}
+
+func TestMagicValueChips(t *testing.T) {
+	// ESP8266, ESP32, ESP32-S2 use magic value detection
+	magicChips := []*chipDef{defESP8266, defESP32, defESP32S2}
+	for _, def := range magicChips {
+		if !def.UsesMagicValue {
+			t.Errorf("%s should use magic value detection", def.Name)
+		}
+		if def.MagicValue == 0 {
+			t.Errorf("%s magic value should not be 0", def.Name)
+		}
+	}
+
+	// Newer chips don't use magic value detection
+	nonMagicChips := []*chipDef{defESP32C3, defESP32C6, defESP32H2}
+	for _, def := range nonMagicChips {
+		if def.UsesMagicValue {
+			t.Errorf("%s should not use magic value detection", def.Name)
+		}
+	}
+}
+
+func TestChipDetectMagicRegAddr(t *testing.T) {
+	if chipDetectMagicRegAddr != 0x40001000 {
+		t.Errorf("chipDetectMagicRegAddr = 0x%08X, want 0x40001000", chipDetectMagicRegAddr)
+	}
+}
+
+func TestFlashFrequencyNonEmpty(t *testing.T) {
+	// All chips should have at least one flash frequency entry.
+	for ct, def := range chipDefs {
+		if len(def.FlashFrequency) == 0 {
+			t.Errorf("%s (ChipType=%d) has no flash frequencies", def.Name, ct)
+		}
+	}
+
+	// ESP32-family chips (not C2/H2) should support "40m"
+	for _, def := range []*chipDef{defESP8266, defESP32, defESP32S2, defESP32S3, defESP32C3, defESP32C6} {
+		if _, ok := def.FlashFrequency["40m"]; !ok {
+			t.Errorf("%s missing 40m flash frequency", def.Name)
+		}
+	}
+
+	// ESP32-C2 uses different freq names
+	if _, ok := defESP32C2.FlashFrequency["60m"]; !ok {
+		t.Error("ESP32-C2 missing 60m flash frequency")
+	}
+
+	// ESP32-H2 uses different freq names
+	if _, ok := defESP32H2.FlashFrequency["48m"]; !ok {
+		t.Error("ESP32-H2 missing 48m flash frequency")
+	}
+}
+
+func TestBootloaderFlashOffset(t *testing.T) {
+	// ESP8266 and some RISC-V chips use offset 0x0; ESP32/S2/S3 use 0x1000.
+	if defESP8266.BootloaderFlashOffset != 0x0 {
+		t.Errorf("ESP8266 bootloader offset = 0x%X, want 0x0", defESP8266.BootloaderFlashOffset)
+	}
+	if defESP32.BootloaderFlashOffset != 0x1000 {
+		t.Errorf("ESP32 bootloader offset = 0x%X, want 0x1000", defESP32.BootloaderFlashOffset)
+	}
+}

--- a/errors_test.go
+++ b/errors_test.go
@@ -1,0 +1,109 @@
+package espflash
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestCommandError(t *testing.T) {
+	tests := []struct {
+		name     string
+		errCode  byte
+		contains string
+	}{
+		{"invalid message", 0x05, "received message is invalid"},
+		{"failed to act", 0x06, "failed to act on received message"},
+		{"invalid CRC", 0x07, "invalid CRC in message"},
+		{"flash write", 0x08, "flash write error"},
+		{"flash read", 0x09, "flash read error"},
+		{"flash read length", 0x0A, "flash read length error"},
+		{"deflate error", 0x0B, "deflate error"},
+		{"unknown error", 0xFF, "unknown error"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := &CommandError{
+				OpCode:  0x02,
+				Status:  0x01,
+				ErrCode: tt.errCode,
+			}
+			msg := err.Error()
+			if !strings.Contains(msg, tt.contains) {
+				t.Errorf("CommandError.Error() = %q, want to contain %q", msg, tt.contains)
+			}
+			// Should include the opcode hex
+			if !strings.Contains(msg, "0x02") {
+				t.Errorf("CommandError.Error() = %q, should contain opcode 0x02", msg)
+			}
+		})
+	}
+}
+
+func TestCommandErrorFormat(t *testing.T) {
+	err := &CommandError{OpCode: 0x10, Status: 0x01, ErrCode: 0x05}
+	msg := err.Error()
+	// Should have format: "command 0x10 failed: status=0x01 error=0x05 (received message is invalid)"
+	if !strings.HasPrefix(msg, "command 0x10 failed:") {
+		t.Errorf("unexpected format: %q", msg)
+	}
+	if !strings.Contains(msg, "status=0x01") {
+		t.Errorf("missing status in: %q", msg)
+	}
+	if !strings.Contains(msg, "error=0x05") {
+		t.Errorf("missing error code in: %q", msg)
+	}
+}
+
+func TestTimeoutError(t *testing.T) {
+	err := &TimeoutError{Op: "sync"}
+	msg := err.Error()
+	if !strings.Contains(msg, "timeout") {
+		t.Errorf("TimeoutError.Error() = %q, should contain 'timeout'", msg)
+	}
+	if !strings.Contains(msg, "sync") {
+		t.Errorf("TimeoutError.Error() = %q, should contain op name", msg)
+	}
+}
+
+func TestSyncError(t *testing.T) {
+	err := &SyncError{Attempts: 7}
+	msg := err.Error()
+	if !strings.Contains(msg, "sync") {
+		t.Errorf("SyncError.Error() = %q, should contain 'sync'", msg)
+	}
+	if !strings.Contains(msg, "7") {
+		t.Errorf("SyncError.Error() = %q, should contain attempt count", msg)
+	}
+}
+
+func TestChipDetectError(t *testing.T) {
+	err := &ChipDetectError{MagicValue: 0xDEADBEEF}
+	msg := err.Error()
+	if !strings.Contains(msg, "detect") {
+		t.Errorf("ChipDetectError.Error() = %q, should contain 'detect'", msg)
+	}
+	if !strings.Contains(msg, "DEADBEEF") {
+		t.Errorf("ChipDetectError.Error() = %q, should contain magic value hex", msg)
+	}
+}
+
+func TestUnsupportedCommandError(t *testing.T) {
+	err := &UnsupportedCommandError{Command: "erase flash (requires stub)"}
+	msg := err.Error()
+	if !strings.Contains(msg, "not supported") {
+		t.Errorf("UnsupportedCommandError.Error() = %q, should contain 'not supported'", msg)
+	}
+	if !strings.Contains(msg, "erase flash") {
+		t.Errorf("UnsupportedCommandError.Error() = %q, should contain command name", msg)
+	}
+}
+
+func TestErrorsImplementErrorInterface(t *testing.T) {
+	// Verify all error types implement the error interface.
+	var _ error = &CommandError{}
+	var _ error = &TimeoutError{}
+	var _ error = &SyncError{}
+	var _ error = &ChipDetectError{}
+	var _ error = &UnsupportedCommandError{}
+}

--- a/flasher_test.go
+++ b/flasher_test.go
@@ -1,0 +1,214 @@
+package espflash
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestDefaultOptions(t *testing.T) {
+	opts := DefaultOptions()
+
+	if opts.BaudRate != 115200 {
+		t.Errorf("BaudRate = %d, want 115200", opts.BaudRate)
+	}
+	if opts.FlashBaudRate != 460800 {
+		t.Errorf("FlashBaudRate = %d, want 460800", opts.FlashBaudRate)
+	}
+	if opts.ChipType != ChipAuto {
+		t.Errorf("ChipType = %v, want ChipAuto", opts.ChipType)
+	}
+	if opts.ConnectAttempts != 7 {
+		t.Errorf("ConnectAttempts = %d, want 7", opts.ConnectAttempts)
+	}
+	if !opts.Compress {
+		t.Error("Compress should default to true")
+	}
+	if opts.FlashMode != "" {
+		t.Errorf("FlashMode = %q, want empty", opts.FlashMode)
+	}
+	if opts.FlashFreq != "" {
+		t.Errorf("FlashFreq = %q, want empty", opts.FlashFreq)
+	}
+	if opts.FlashSize != "" {
+		t.Errorf("FlashSize = %q, want empty", opts.FlashSize)
+	}
+	if opts.Logger != nil {
+		t.Error("Logger should default to nil")
+	}
+}
+
+func TestCompressData(t *testing.T) {
+	// Compressible data: repeated bytes
+	data := bytes.Repeat([]byte{0xAA}, 4096)
+	compressed, err := compressData(data)
+	if err != nil {
+		t.Fatalf("compressData failed: %v", err)
+	}
+	if len(compressed) >= len(data) {
+		t.Errorf("compressed (%d bytes) should be smaller than original (%d bytes)",
+			len(compressed), len(data))
+	}
+	if len(compressed) == 0 {
+		t.Error("compressed data should not be empty")
+	}
+}
+
+func TestCompressDataSmall(t *testing.T) {
+	// Very small data may not compress well
+	data := []byte{0x01, 0x02, 0x03}
+	compressed, err := compressData(data)
+	if err != nil {
+		t.Fatalf("compressData failed: %v", err)
+	}
+	// Should still produce valid output even if larger
+	if len(compressed) == 0 {
+		t.Error("compressed data should not be empty")
+	}
+}
+
+func TestCompressDataEmpty(t *testing.T) {
+	compressed, err := compressData([]byte{})
+	if err != nil {
+		t.Fatalf("compressData failed: %v", err)
+	}
+	// Even empty input should produce a valid zlib stream
+	if len(compressed) == 0 {
+		t.Error("compressed data of empty input should not be empty")
+	}
+}
+
+func TestLogfNilLogger(t *testing.T) {
+	// Ensure logf with nil logger doesn't panic
+	f := &Flasher{opts: &FlasherOptions{Logger: nil}}
+	f.logf("test %s %d", "hello", 42) // should not panic
+}
+
+func TestLogfWithLogger(t *testing.T) {
+	var buf bytes.Buffer
+	logger := &StdoutLogger{W: &buf}
+	f := &Flasher{opts: &FlasherOptions{Logger: logger}}
+	f.logf("hello %s", "world")
+
+	got := buf.String()
+	if got != "hello world\n" {
+		t.Errorf("logf output = %q, want %q", got, "hello world\n")
+	}
+}
+
+func TestStdoutLogger(t *testing.T) {
+	var buf bytes.Buffer
+	logger := &StdoutLogger{W: &buf}
+	logger.Logf("test %d", 42)
+	if buf.String() != "test 42\n" {
+		t.Errorf("Logf output = %q, want %q", buf.String(), "test 42\n")
+	}
+}
+
+func TestAttachFlashSkipsESP8266(t *testing.T) {
+	// ESP8266 ROM does not support SPI_ATTACH - attachFlash should skip it.
+	f := &Flasher{
+		chip: defESP8266,
+		opts: DefaultOptions(),
+	}
+	// If it tried to send SPI_ATTACH, it would panic (no port).
+	err := f.attachFlash()
+	if err != nil {
+		t.Errorf("attachFlash for ESP8266 should return nil, got: %v", err)
+	}
+}
+
+func TestEraseRegionAlignment(t *testing.T) {
+	f := &Flasher{
+		opts: DefaultOptions(),
+		conn: &conn{},
+	}
+
+	// Misaligned offset
+	err := f.EraseRegion(0x100, 0x1000)
+	if err == nil {
+		t.Error("expected error for misaligned offset")
+	}
+
+	// Misaligned size
+	err = f.EraseRegion(0x1000, 0x100)
+	if err == nil {
+		t.Error("expected error for misaligned size")
+	}
+}
+
+func TestFlashImageEmptyData(t *testing.T) {
+	f := &Flasher{
+		opts: DefaultOptions(),
+		chip: defESP32,
+		conn: &conn{},
+	}
+
+	err := f.FlashImage(nil, 0, nil)
+	if err == nil {
+		t.Error("expected error for nil image data")
+	}
+
+	err = f.FlashImage([]byte{}, 0, nil)
+	if err == nil {
+		t.Error("expected error for empty image data")
+	}
+}
+
+func TestImagePart(t *testing.T) {
+	// Verify ImagePart struct can hold data and offset.
+	part := ImagePart{
+		Data:   []byte{0xE9, 0x00, 0x02, 0x20},
+		Offset: 0x1000,
+	}
+	if len(part.Data) != 4 {
+		t.Errorf("ImagePart.Data len = %d, want 4", len(part.Data))
+	}
+	if part.Offset != 0x1000 {
+		t.Errorf("ImagePart.Offset = 0x%X, want 0x1000", part.Offset)
+	}
+}
+
+func TestFlasherChipType(t *testing.T) {
+	// With chip set
+	f := &Flasher{chip: defESP32, opts: DefaultOptions()}
+	if f.ChipType() != ChipESP32 {
+		t.Errorf("ChipType() = %v, want ChipESP32", f.ChipType())
+	}
+
+	// Without chip set
+	f2 := &Flasher{opts: DefaultOptions()}
+	if f2.ChipType() != ChipAuto {
+		t.Errorf("ChipType() = %v, want ChipAuto", f2.ChipType())
+	}
+}
+
+func TestFlasherChipName(t *testing.T) {
+	f := &Flasher{chip: defESP32S3, opts: DefaultOptions()}
+	if f.ChipName() != "ESP32-S3" {
+		t.Errorf("ChipName() = %q, want %q", f.ChipName(), "ESP32-S3")
+	}
+
+	f2 := &Flasher{opts: DefaultOptions()}
+	if f2.ChipName() != "Unknown" {
+		t.Errorf("ChipName() = %q, want %q", f2.ChipName(), "Unknown")
+	}
+}
+
+func TestFlashImagePatchesHeader(t *testing.T) {
+	// Verify that FlashImage calls patchImageHeader by checking that an
+	// invalid flash mode causes an error.
+	f := &Flasher{
+		opts: &FlasherOptions{
+			FlashMode: "invalid_mode",
+			Compress:  false,
+		},
+		chip: defESP32,
+		conn: &conn{},
+	}
+
+	data := makeESPImage(FlashModeDIO, 0x20)
+	err := f.FlashImage(data, 0, nil)
+	if err == nil {
+		t.Error("expected error from invalid flash mode during patchImageHeader")
+	}
+}

--- a/image_test.go
+++ b/image_test.go
@@ -1,0 +1,375 @@
+package espflash
+
+import (
+	"crypto/sha256"
+	"testing"
+)
+
+// testFlasher creates a minimal Flasher for testing patchImageHeader.
+func testFlasher(opts *FlasherOptions, chip *chipDef) *Flasher {
+	if opts == nil {
+		opts = DefaultOptions()
+	}
+	return &Flasher{
+		opts: opts,
+		chip: chip,
+	}
+}
+
+// makeESPImage creates a minimal valid ESP image header for testing.
+// Returns a 64-byte image (header + padding) with the given mode, sizeFreq byte.
+func makeESPImage(mode byte, sizeFreq byte) []byte {
+	data := make([]byte, 64)
+	data[0] = espImageMagic
+	data[1] = 0x00 // segment count
+	data[2] = mode
+	data[3] = sizeFreq
+	return data
+}
+
+// makeESPImageWithSHA creates an ESP image with an appended SHA256 hash.
+// byte 23 bit 0 = 1 indicates SHA is present.
+func makeESPImageWithSHA(mode byte, sizeFreq byte) []byte {
+	data := make([]byte, 64+32) // 64 bytes content + 32 bytes SHA256
+	data[0] = espImageMagic
+	data[1] = 0x00
+	data[2] = mode
+	data[3] = sizeFreq
+	data[23] = 0x01 // SHA256 flag
+
+	// Compute and append valid SHA256
+	content := data[:64]
+	hash := sha256.Sum256(content)
+	copy(data[64:], hash[:])
+	return data
+}
+
+func TestPatchImageHeader_NoESPImage(t *testing.T) {
+	f := testFlasher(&FlasherOptions{FlashMode: "dout"}, defESP32)
+	data := []byte{0x00, 0x01, 0x02, 0x03}
+	result, err := f.patchImageHeader(data)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if &result[0] != &data[0] {
+		t.Error("expected same slice back for non-ESP image")
+	}
+}
+
+func TestPatchImageHeader_TooShort(t *testing.T) {
+	f := testFlasher(&FlasherOptions{FlashMode: "dout"}, defESP32)
+	data := []byte{espImageMagic, 0x00}
+	result, err := f.patchImageHeader(data)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if &result[0] != &data[0] {
+		t.Error("expected same slice back for too-short image")
+	}
+}
+
+func TestPatchImageHeader_KeepMode(t *testing.T) {
+	f := testFlasher(&FlasherOptions{FlashMode: "keep"}, defESP32)
+	data := makeESPImage(FlashModeDIO, 0x2F) // dio, 80m, 4MB
+	result, err := f.patchImageHeader(data)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// "keep" should return original data unmodified
+	if &result[0] != &data[0] {
+		t.Error("expected same slice back when keeping all params")
+	}
+}
+
+func TestPatchImageHeader_NoOptions(t *testing.T) {
+	f := testFlasher(&FlasherOptions{}, defESP32)
+	data := makeESPImage(FlashModeDIO, 0x2F)
+	result, err := f.patchImageHeader(data)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if &result[0] != &data[0] {
+		t.Error("expected same slice back when no options set")
+	}
+}
+
+func TestPatchImageHeader_FlashMode(t *testing.T) {
+	tests := []struct {
+		mode     string
+		expected byte
+	}{
+		{"qio", FlashModeQIO},
+		{"qout", FlashModeQOUT},
+		{"dio", FlashModeDIO},
+		{"dout", FlashModeDOUT},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.mode, func(t *testing.T) {
+			f := testFlasher(&FlasherOptions{FlashMode: tt.mode}, defESP32)
+			data := makeESPImage(0xFF, 0x00)
+			result, err := f.patchImageHeader(data)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if result[2] != tt.expected {
+				t.Errorf("flash mode byte = 0x%02X, want 0x%02X", result[2], tt.expected)
+			}
+		})
+	}
+}
+
+func TestPatchImageHeader_InvalidFlashMode(t *testing.T) {
+	f := testFlasher(&FlasherOptions{FlashMode: "invalid"}, defESP32)
+	data := makeESPImage(0x00, 0x00)
+	_, err := f.patchImageHeader(data)
+	if err == nil {
+		t.Fatal("expected error for invalid flash mode")
+	}
+}
+
+func TestPatchImageHeader_FlashFreq(t *testing.T) {
+	tests := []struct {
+		freq     string
+		expected byte
+	}{
+		{"80m", 0x0F},
+		{"40m", 0x00},
+		{"26m", 0x01},
+		{"20m", 0x02},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.freq, func(t *testing.T) {
+			f := testFlasher(&FlasherOptions{FlashFreq: tt.freq}, defESP32)
+			data := makeESPImage(0x00, 0xFF) // sizeFreq = 0xFF
+			result, err := f.patchImageHeader(data)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			gotFreq := result[3] & 0x0F
+			if gotFreq != tt.expected {
+				t.Errorf("flash freq nibble = 0x%02X, want 0x%02X", gotFreq, tt.expected)
+			}
+			// Upper nibble should be preserved
+			gotSize := result[3] & 0xF0
+			if gotSize != 0xF0 {
+				t.Errorf("flash size nibble changed: got 0x%02X, want 0xF0", gotSize)
+			}
+		})
+	}
+}
+
+func TestPatchImageHeader_FlashSize(t *testing.T) {
+	tests := []struct {
+		size     string
+		expected byte // upper nibble value
+	}{
+		{"1MB", 0x00},
+		{"2MB", 0x10},
+		{"4MB", 0x20},
+		{"8MB", 0x30},
+		{"16MB", 0x40},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.size, func(t *testing.T) {
+			f := testFlasher(&FlasherOptions{FlashSize: tt.size}, defESP32)
+			data := makeESPImage(0x00, 0xFF) // sizeFreq = 0xFF
+			result, err := f.patchImageHeader(data)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			gotSize := result[3] & 0xF0
+			if gotSize != tt.expected {
+				t.Errorf("flash size nibble = 0x%02X, want 0x%02X", gotSize, tt.expected)
+			}
+			// Lower nibble should be preserved
+			gotFreq := result[3] & 0x0F
+			if gotFreq != 0x0F {
+				t.Errorf("flash freq nibble changed: got 0x%02X, want 0x0F", gotFreq)
+			}
+		})
+	}
+}
+
+func TestPatchImageHeader_FlashFreqNoChip(t *testing.T) {
+	f := testFlasher(&FlasherOptions{FlashFreq: "40m"}, nil)
+	data := makeESPImage(0x00, 0x00)
+	_, err := f.patchImageHeader(data)
+	if err == nil {
+		t.Fatal("expected error when chip is nil and FlashFreq is set")
+	}
+}
+
+func TestPatchImageHeader_FlashSizeNoChip(t *testing.T) {
+	f := testFlasher(&FlasherOptions{FlashSize: "4MB"}, nil)
+	data := makeESPImage(0x00, 0x00)
+	_, err := f.patchImageHeader(data)
+	if err == nil {
+		t.Fatal("expected error when chip is nil and FlashSize is set")
+	}
+}
+
+func TestPatchImageHeader_InvalidFlashFreq(t *testing.T) {
+	f := testFlasher(&FlasherOptions{FlashFreq: "999m"}, defESP32)
+	data := makeESPImage(0x00, 0x00)
+	_, err := f.patchImageHeader(data)
+	if err == nil {
+		t.Fatal("expected error for invalid flash frequency")
+	}
+}
+
+func TestPatchImageHeader_InvalidFlashSize(t *testing.T) {
+	f := testFlasher(&FlasherOptions{FlashSize: "999MB"}, defESP32)
+	data := makeESPImage(0x00, 0x00)
+	_, err := f.patchImageHeader(data)
+	if err == nil {
+		t.Fatal("expected error for invalid flash size")
+	}
+}
+
+func TestPatchImageHeader_CombineModeFreqSize(t *testing.T) {
+	f := testFlasher(&FlasherOptions{
+		FlashMode: "dout",
+		FlashFreq: "80m",
+		FlashSize: "4MB",
+	}, defESP32)
+
+	data := makeESPImage(0x00, 0x00) // start with all zeros
+	result, err := f.patchImageHeader(data)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result[2] != FlashModeDOUT {
+		t.Errorf("mode = 0x%02X, want 0x%02X", result[2], FlashModeDOUT)
+	}
+	// byte 3: size=0x20 (4MB) | freq=0x0F (80m) = 0x2F
+	if result[3] != 0x2F {
+		t.Errorf("sizeFreq = 0x%02X, want 0x2F", result[3])
+	}
+}
+
+func TestPatchImageHeader_DoesNotModifyOriginal(t *testing.T) {
+	f := testFlasher(&FlasherOptions{FlashMode: "dout"}, defESP32)
+	data := makeESPImage(FlashModeQIO, 0x00)
+	originalByte2 := data[2]
+	result, err := f.patchImageHeader(data)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Original should not be modified
+	if data[2] != originalByte2 {
+		t.Error("patchImageHeader modified the original data")
+	}
+	// Result should be different
+	if result[2] != FlashModeDOUT {
+		t.Errorf("result mode = 0x%02X, want 0x%02X", result[2], FlashModeDOUT)
+	}
+}
+
+func TestPatchImageHeader_SHA256Updated(t *testing.T) {
+	f := testFlasher(&FlasherOptions{FlashMode: "dout"}, defESP32)
+	data := makeESPImageWithSHA(FlashModeQIO, 0x00)
+
+	result, err := f.patchImageHeader(data)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Verify the SHA256 was recomputed
+	content := result[:len(result)-32]
+	expectedHash := sha256.Sum256(content)
+	actualHash := result[len(result)-32:]
+	for i := 0; i < 32; i++ {
+		if actualHash[i] != expectedHash[i] {
+			t.Errorf("SHA256 mismatch at byte %d: got 0x%02X, want 0x%02X",
+				i, actualHash[i], expectedHash[i])
+		}
+	}
+}
+
+func TestPatchImageHeader_SHA256NotUpdatedForESP8266(t *testing.T) {
+	f := testFlasher(&FlasherOptions{FlashMode: "dout"}, defESP8266)
+	data := makeESPImageWithSHA(FlashModeQIO, 0x00)
+	origSHA := make([]byte, 32)
+	copy(origSHA, data[len(data)-32:])
+
+	result, err := f.patchImageHeader(data)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// ESP8266 should NOT update SHA256 (no extended header)
+	actualSHA := result[len(result)-32:]
+	for i := 0; i < 32; i++ {
+		if actualSHA[i] != origSHA[i] {
+			t.Error("SHA256 was updated for ESP8266, but should not have been")
+			break
+		}
+	}
+}
+
+func TestPatchImageHeader_ESP8266FlashSizes(t *testing.T) {
+	tests := []struct {
+		size     string
+		expected byte
+	}{
+		{"512KB", 0x00},
+		{"256KB", 0x10},
+		{"1MB", 0x20},
+		{"2MB", 0x30},
+		{"4MB", 0x40},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.size, func(t *testing.T) {
+			f := testFlasher(&FlasherOptions{FlashSize: tt.size}, defESP8266)
+			data := makeESPImage(0x00, 0x00)
+			result, err := f.patchImageHeader(data)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			gotSize := result[3] & 0xF0
+			if gotSize != tt.expected {
+				t.Errorf("ESP8266 flash size for %s: got 0x%02X, want 0x%02X",
+					tt.size, gotSize, tt.expected)
+			}
+		})
+	}
+}
+
+func TestFlashModeConstants(t *testing.T) {
+	// Verify flash mode constants match the documented values.
+	if FlashModeQIO != 0x00 {
+		t.Errorf("FlashModeQIO = 0x%02X, want 0x00", FlashModeQIO)
+	}
+	if FlashModeQOUT != 0x01 {
+		t.Errorf("FlashModeQOUT = 0x%02X, want 0x01", FlashModeQOUT)
+	}
+	if FlashModeDIO != 0x02 {
+		t.Errorf("FlashModeDIO = 0x%02X, want 0x02", FlashModeDIO)
+	}
+	if FlashModeDOUT != 0x03 {
+		t.Errorf("FlashModeDOUT = 0x%02X, want 0x03", FlashModeDOUT)
+	}
+}
+
+func TestFlashModeNames(t *testing.T) {
+	expected := map[string]byte{
+		"qio":  0x00,
+		"qout": 0x01,
+		"dio":  0x02,
+		"dout": 0x03,
+	}
+	for name, val := range expected {
+		got, ok := flashModeNames[name]
+		if !ok {
+			t.Errorf("flashModeNames missing %q", name)
+			continue
+		}
+		if got != val {
+			t.Errorf("flashModeNames[%q] = 0x%02X, want 0x%02X", name, got, val)
+		}
+	}
+}

--- a/protocol_test.go
+++ b/protocol_test.go
@@ -1,0 +1,446 @@
+package espflash
+
+import (
+	"encoding/binary"
+	"testing"
+	"time"
+
+	"go.bug.st/serial"
+)
+
+func TestChecksum(t *testing.T) {
+	tests := []struct {
+		name     string
+		data     []byte
+		expected uint32
+	}{
+		{
+			name:     "empty data",
+			data:     []byte{},
+			expected: checksumMagic,
+		},
+		{
+			name:     "single byte zero",
+			data:     []byte{0x00},
+			expected: checksumMagic ^ 0x00,
+		},
+		{
+			name:     "single byte 0xFF",
+			data:     []byte{0xFF},
+			expected: checksumMagic ^ 0xFF,
+		},
+		{
+			name:     "XOR identity: same byte twice",
+			data:     []byte{0x42, 0x42},
+			expected: checksumMagic, // XOR cancels out
+		},
+		{
+			name:     "three bytes",
+			data:     []byte{0x01, 0x02, 0x03},
+			expected: checksumMagic ^ 0x01 ^ 0x02 ^ 0x03,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := checksum(tt.data)
+			if result != tt.expected {
+				t.Errorf("checksum(%X) = 0x%08X, want 0x%08X", tt.data, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestFlashWriteSize(t *testing.T) {
+	romConn := &conn{isStub: false}
+	if romConn.flashWriteSize() != flashWriteSizeROM {
+		t.Errorf("ROM write size = %d, want %d", romConn.flashWriteSize(), flashWriteSizeROM)
+	}
+
+	stubConn := &conn{isStub: true}
+	if stubConn.flashWriteSize() != flashWriteSizeStub {
+		t.Errorf("Stub write size = %d, want %d", stubConn.flashWriteSize(), flashWriteSizeStub)
+	}
+}
+
+func TestEraseTimeoutForSize(t *testing.T) {
+	tests := []struct {
+		name string
+		size uint32
+		min  time.Duration
+	}{
+		{
+			name: "zero size has minimum",
+			size: 0,
+			min:  10 * time.Second,
+		},
+		{
+			name: "small size has minimum",
+			size: 4096,
+			min:  10 * time.Second,
+		},
+		{
+			name: "1MB has base + rate",
+			size: 1024 * 1024,
+			min:  10 * time.Second,
+		},
+		{
+			name: "10MB is larger",
+			size: 10 * 1024 * 1024,
+			min:  10 * time.Second,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			timeout := eraseTimeoutForSize(tt.size)
+			if timeout < tt.min {
+				t.Errorf("eraseTimeoutForSize(%d) = %v, want >= %v", tt.size, timeout, tt.min)
+			}
+		})
+	}
+
+	// Verify larger sizes get longer timeouts
+	small := eraseTimeoutForSize(1024)
+	large := eraseTimeoutForSize(100 * 1024 * 1024)
+	if large <= small {
+		t.Errorf("expected larger timeout for bigger size: small=%v large=%v", small, large)
+	}
+}
+
+func TestSendCommandFormat(t *testing.T) {
+	// Test that sendCommand builds the correct packet structure using a mock port.
+	var written []byte
+	mock := &mockPort{
+		writeFunc: func(data []byte) (int, error) {
+			written = append(written, data...)
+			return len(data), nil
+		},
+	}
+
+	c := &conn{
+		port:   mock,
+		reader: &slipReader{port: mock},
+	}
+
+	testData := []byte{0x01, 0x02, 0x03, 0x04}
+	chk := uint32(0xABCD)
+
+	err := c.sendCommand(cmdSync, testData, chk)
+	if err != nil {
+		t.Fatalf("sendCommand failed: %v", err)
+	}
+
+	// Decode the SLIP frame
+	decoded := slipDecode(written)
+
+	if len(decoded) < 8+len(testData) {
+		t.Fatalf("decoded packet too short: %d bytes", len(decoded))
+	}
+
+	// Check header fields
+	if decoded[0] != respDirectionReq {
+		t.Errorf("direction = 0x%02X, want 0x%02X", decoded[0], respDirectionReq)
+	}
+	if decoded[1] != cmdSync {
+		t.Errorf("opcode = 0x%02X, want 0x%02X", decoded[1], cmdSync)
+	}
+
+	dataLen := binary.LittleEndian.Uint16(decoded[2:4])
+	if dataLen != uint16(len(testData)) {
+		t.Errorf("data length = %d, want %d", dataLen, len(testData))
+	}
+
+	chkField := binary.LittleEndian.Uint32(decoded[4:8])
+	if chkField != chk {
+		t.Errorf("checksum field = 0x%08X, want 0x%08X", chkField, chk)
+	}
+
+	// Check data payload
+	for i := 0; i < len(testData); i++ {
+		if decoded[8+i] != testData[i] {
+			t.Errorf("data[%d] = 0x%02X, want 0x%02X", i, decoded[8+i], testData[i])
+		}
+	}
+}
+
+func TestFlashBeginParamLength(t *testing.T) {
+	// Verify that flash begin sends 16 bytes for older chips and 20 for newer.
+	tests := []struct {
+		name           string
+		supportsEncr   bool
+		isStub         bool
+		expectedMinLen int // minimum data length in the command
+	}{
+		{"old ROM", false, false, 16},
+		{"new ROM", true, false, 20},
+		{"stub", false, true, 20},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var written []byte
+			mock := &mockPort{
+				writeFunc: func(data []byte) (int, error) {
+					written = data
+					return len(data), nil
+				},
+				readFunc: func(buf []byte) (int, error) {
+					// Return a valid response frame
+					resp := makeFlashBeginResponse()
+					frame := slipEncode(resp)
+					n := copy(buf, frame)
+					return n, nil
+				},
+			}
+
+			c := &conn{
+				port:                   mock,
+				reader:                 newSlipReader(mock),
+				isStub:                 tt.isStub,
+				supportsEncryptedFlash: tt.supportsEncr,
+			}
+
+			_ = c.flashBegin(4096, 0x1000, false) // ignore errors from mock
+
+			// Decode the SLIP frame to get the packet
+			decoded := slipDecode(written)
+			if len(decoded) < 8 {
+				t.Fatalf("packet too short: %d bytes", len(decoded))
+			}
+
+			// Data length is in the packet header
+			dataLen := int(binary.LittleEndian.Uint16(decoded[2:4]))
+			if dataLen < tt.expectedMinLen {
+				t.Errorf("flash begin data length = %d, want >= %d", dataLen, tt.expectedMinLen)
+			}
+		})
+	}
+}
+
+func TestFlashDeflBeginParamLength(t *testing.T) {
+	tests := []struct {
+		name           string
+		supportsEncr   bool
+		isStub         bool
+		expectedMinLen int
+	}{
+		{"old ROM", false, false, 16},
+		{"new ROM", true, false, 20},
+		{"stub", false, true, 20},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var written []byte
+			mock := &mockPort{
+				writeFunc: func(data []byte) (int, error) {
+					written = data
+					return len(data), nil
+				},
+				readFunc: func(buf []byte) (int, error) {
+					resp := makeFlashBeginResponse()
+					frame := slipEncode(resp)
+					n := copy(buf, frame)
+					return n, nil
+				},
+			}
+
+			c := &conn{
+				port:                   mock,
+				reader:                 newSlipReader(mock),
+				isStub:                 tt.isStub,
+				supportsEncryptedFlash: tt.supportsEncr,
+			}
+
+			_ = c.flashDeflBegin(4096, 2048, 0x1000, false)
+
+			decoded := slipDecode(written)
+			if len(decoded) < 8 {
+				t.Fatalf("packet too short: %d bytes", len(decoded))
+			}
+
+			dataLen := int(binary.LittleEndian.Uint16(decoded[2:4]))
+			if dataLen < tt.expectedMinLen {
+				t.Errorf("flash defl begin data length = %d, want >= %d", dataLen, tt.expectedMinLen)
+			}
+		})
+	}
+}
+
+func TestChangeBaudSecondParam(t *testing.T) {
+	// ROM: second param should be 0
+	// Stub: second param should be oldBaud
+	tests := []struct {
+		name      string
+		isStub    bool
+		newBaud   uint32
+		oldBaud   uint32
+		expect2nd uint32
+	}{
+		{"ROM sends 0", false, 460800, 115200, 0},
+		{"Stub sends oldBaud", true, 460800, 115200, 115200},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var written []byte
+			mock := &mockPort{
+				writeFunc: func(data []byte) (int, error) {
+					written = data
+					return len(data), nil
+				},
+				readFunc: func(buf []byte) (int, error) {
+					resp := makeChangeBaudResponse()
+					frame := slipEncode(resp)
+					n := copy(buf, frame)
+					return n, nil
+				},
+			}
+
+			c := &conn{
+				port:   mock,
+				reader: newSlipReader(mock),
+				isStub: tt.isStub,
+			}
+
+			_ = c.changeBaud(tt.newBaud, tt.oldBaud)
+
+			decoded := slipDecode(written)
+			if len(decoded) < 8+8 {
+				t.Fatalf("packet too short: %d bytes", len(decoded))
+			}
+
+			// Data starts at offset 8 in the decoded packet
+			secondParam := binary.LittleEndian.Uint32(decoded[8+4 : 8+8])
+			if secondParam != tt.expect2nd {
+				t.Errorf("second param = %d, want %d", secondParam, tt.expect2nd)
+			}
+		})
+	}
+}
+
+func TestProtocolConstants(t *testing.T) {
+	// Verify protocol constants match the ESP bootloader spec.
+	if checksumMagic != 0xEF {
+		t.Errorf("checksumMagic = 0x%02X, want 0xEF", checksumMagic)
+	}
+	if flashWriteSizeROM != 0x400 {
+		t.Errorf("flashWriteSizeROM = 0x%X, want 0x400", flashWriteSizeROM)
+	}
+	if flashWriteSizeStub != 0x4000 {
+		t.Errorf("flashWriteSizeStub = 0x%X, want 0x4000", flashWriteSizeStub)
+	}
+	if flashSectorSize != 0x1000 {
+		t.Errorf("flashSectorSize = 0x%X, want 0x1000", flashSectorSize)
+	}
+	if espImageMagic != 0xE9 {
+		t.Errorf("espImageMagic = 0x%02X, want 0xE9", espImageMagic)
+	}
+}
+
+func TestCommandOpcodes(t *testing.T) {
+	// Verify key command opcodes.
+	expected := map[string]byte{
+		"FLASH_BEGIN":     0x02,
+		"FLASH_DATA":      0x03,
+		"FLASH_END":       0x04,
+		"MEM_BEGIN":       0x05,
+		"MEM_END":         0x06,
+		"MEM_DATA":        0x07,
+		"SYNC":            0x08,
+		"WRITE_REG":       0x09,
+		"READ_REG":        0x0A,
+		"SPI_SET_PARAMS":  0x0B,
+		"SPI_ATTACH":      0x0D,
+		"CHANGE_BAUD":     0x0F,
+		"FLASH_DEFL_BEG":  0x10,
+		"FLASH_DEFL_DATA": 0x11,
+		"FLASH_DEFL_END":  0x12,
+		"SPI_FLASH_MD5":   0x13,
+	}
+
+	actual := map[string]byte{
+		"FLASH_BEGIN":     cmdFlashBegin,
+		"FLASH_DATA":      cmdFlashData,
+		"FLASH_END":       cmdFlashEnd,
+		"MEM_BEGIN":       cmdMemBegin,
+		"MEM_END":         cmdMemEnd,
+		"MEM_DATA":        cmdMemData,
+		"SYNC":            cmdSync,
+		"WRITE_REG":       cmdWriteReg,
+		"READ_REG":        cmdReadReg,
+		"SPI_SET_PARAMS":  cmdSPISetParams,
+		"SPI_ATTACH":      cmdSPIAttach,
+		"CHANGE_BAUD":     cmdChangeBaud,
+		"FLASH_DEFL_BEG":  cmdFlashDeflBeg,
+		"FLASH_DEFL_DATA": cmdFlashDeflData,
+		"FLASH_DEFL_END":  cmdFlashDeflEnd,
+		"SPI_FLASH_MD5":   cmdSPIFlashMD5,
+	}
+
+	for name, exp := range expected {
+		got := actual[name]
+		if got != exp {
+			t.Errorf("cmd%s = 0x%02X, want 0x%02X", name, got, exp)
+		}
+	}
+}
+
+// --- Mock port and response helpers ---
+
+// mockPort implements serial.Port for testing.
+type mockPort struct {
+	writeFunc func([]byte) (int, error)
+	readFunc  func([]byte) (int, error)
+}
+
+func (m *mockPort) Write(p []byte) (int, error) {
+	if m.writeFunc != nil {
+		return m.writeFunc(p)
+	}
+	return len(p), nil
+}
+
+func (m *mockPort) Read(p []byte) (int, error) {
+	if m.readFunc != nil {
+		return m.readFunc(p)
+	}
+	return 0, nil
+}
+
+func (m *mockPort) SetMode(mode *serial.Mode) error                      { return nil }
+func (m *mockPort) SetReadTimeout(t time.Duration) error                 { return nil }
+func (m *mockPort) SetWriteTimeout(t time.Duration) error                { return nil }
+func (m *mockPort) Close() error                                         { return nil }
+func (m *mockPort) ResetInputBuffer() error                              { return nil }
+func (m *mockPort) ResetOutputBuffer() error                             { return nil }
+func (m *mockPort) SetDTR(dtr bool) error                                { return nil }
+func (m *mockPort) SetRTS(rts bool) error                                { return nil }
+func (m *mockPort) GetModemStatusBits() (*serial.ModemStatusBits, error) { return nil, nil }
+func (m *mockPort) Break(t time.Duration) error                          { return nil }
+func (m *mockPort) Drain() error                                         { return nil }
+
+// makeFlashBeginResponse creates a mock response for flash begin command.
+func makeFlashBeginResponse() []byte {
+	resp := make([]byte, 10)
+	resp[0] = respDirectionResp
+	resp[1] = cmdFlashBegin
+	binary.LittleEndian.PutUint16(resp[2:4], 2) // data len = 2
+	binary.LittleEndian.PutUint32(resp[4:8], 0) // value
+	resp[8] = 0x00                              // status OK
+	resp[9] = 0x00                              // error 0
+	return resp
+}
+
+// makeChangeBaudResponse creates a mock response for change baud command.
+func makeChangeBaudResponse() []byte {
+	resp := make([]byte, 10)
+	resp[0] = respDirectionResp
+	resp[1] = cmdChangeBaud
+	binary.LittleEndian.PutUint16(resp[2:4], 2)
+	binary.LittleEndian.PutUint32(resp[4:8], 0)
+	resp[8] = 0x00
+	resp[9] = 0x00
+	return resp
+}

--- a/slip_test.go
+++ b/slip_test.go
@@ -1,0 +1,157 @@
+package espflash
+
+import (
+"bytes"
+"testing"
+)
+
+func TestSlipEncode(t *testing.T) {
+tests := []struct {
+name     string
+input    []byte
+expected []byte
+}{
+{
+name:     "empty data",
+input:    []byte{},
+expected: []byte{0xC0, 0xC0},
+},
+{
+name:     "no special bytes",
+input:    []byte{0x01, 0x02, 0x03},
+expected: []byte{0xC0, 0x01, 0x02, 0x03, 0xC0},
+},
+{
+name:     "escape END byte",
+input:    []byte{0x01, 0xC0, 0x03},
+expected: []byte{0xC0, 0x01, 0xDB, 0xDC, 0x03, 0xC0},
+},
+{
+name:     "escape ESC byte",
+input:    []byte{0x01, 0xDB, 0x03},
+expected: []byte{0xC0, 0x01, 0xDB, 0xDD, 0x03, 0xC0},
+},
+{
+name:     "escape both special bytes",
+input:    []byte{0xC0, 0xDB},
+expected: []byte{0xC0, 0xDB, 0xDC, 0xDB, 0xDD, 0xC0},
+},
+{
+name:     "multiple END bytes",
+input:    []byte{0xC0, 0xC0, 0xC0},
+expected: []byte{0xC0, 0xDB, 0xDC, 0xDB, 0xDC, 0xDB, 0xDC, 0xC0},
+},
+{
+name:     "multiple ESC bytes",
+input:    []byte{0xDB, 0xDB},
+expected: []byte{0xC0, 0xDB, 0xDD, 0xDB, 0xDD, 0xC0},
+},
+{
+name:     "adjacent ESC and END",
+input:    []byte{0xDB, 0xC0},
+expected: []byte{0xC0, 0xDB, 0xDD, 0xDB, 0xDC, 0xC0},
+},
+}
+
+for _, tt := range tests {
+t.Run(tt.name, func(t *testing.T) {
+result := slipEncode(tt.input)
+if !bytes.Equal(result, tt.expected) {
+t.Errorf("slipEncode(%X) = %X, want %X", tt.input, result, tt.expected)
+}
+})
+}
+}
+
+func TestSlipDecode(t *testing.T) {
+tests := []struct {
+name     string
+input    []byte
+expected []byte
+}{
+{
+name:     "no special bytes",
+input:    []byte{0xC0, 0x01, 0x02, 0x03, 0xC0},
+expected: []byte{0x01, 0x02, 0x03},
+},
+{
+name:     "unescape END byte",
+input:    []byte{0xC0, 0x01, 0xDB, 0xDC, 0x03, 0xC0},
+expected: []byte{0x01, 0xC0, 0x03},
+},
+{
+name:     "unescape ESC byte",
+input:    []byte{0xC0, 0x01, 0xDB, 0xDD, 0x03, 0xC0},
+expected: []byte{0x01, 0xDB, 0x03},
+},
+{
+name:     "unescape both",
+input:    []byte{0xDB, 0xDC, 0xDB, 0xDD},
+expected: []byte{0xC0, 0xDB},
+},
+{
+name:     "empty frame",
+input:    []byte{0xC0, 0xC0},
+expected: []byte{},
+},
+{
+name:     "frame delimiters stripped",
+input:    []byte{0xC0, 0x41, 0x42, 0xC0},
+expected: []byte{0x41, 0x42},
+},
+{
+name:     "invalid escape preserved",
+input:    []byte{0xDB, 0x42},
+expected: []byte{0xDB, 0x42},
+},
+}
+
+for _, tt := range tests {
+t.Run(tt.name, func(t *testing.T) {
+result := slipDecode(tt.input)
+if !bytes.Equal(result, tt.expected) {
+t.Errorf("slipDecode(%X) = %X, want %X", tt.input, result, tt.expected)
+}
+})
+}
+}
+
+func TestSlipRoundtrip(t *testing.T) {
+// Encoding then decoding should give back the original data.
+testCases := [][]byte{
+{},
+{0x00},
+{0xFF},
+{0xC0},
+{0xDB},
+{0xC0, 0xDB},
+{0x01, 0x02, 0x03, 0x04, 0x05},
+{0xC0, 0xDB, 0xC0, 0xDB, 0xC0},
+bytes.Repeat([]byte{0xC0}, 10),
+bytes.Repeat([]byte{0xDB}, 10),
+}
+
+for _, data := range testCases {
+encoded := slipEncode(data)
+// Verify frame delimiters
+if encoded[0] != slipEnd || encoded[len(encoded)-1] != slipEnd {
+t.Errorf("slipEncode(%X): missing frame delimiters", data)
+}
+decoded := slipDecode(encoded)
+if !bytes.Equal(decoded, data) {
+t.Errorf("roundtrip failed for %X: got %X", data, decoded)
+}
+}
+}
+
+func TestSlipEncodeNoRawSpecialBytes(t *testing.T) {
+// Verify that encoded data (between delimiters) never contains raw 0xC0.
+data := []byte{0x00, 0xC0, 0xDB, 0xFF, 0xC0, 0xDB, 0x42}
+encoded := slipEncode(data)
+inner := encoded[1 : len(encoded)-1] // strip delimiters
+for i, b := range inner {
+if b == slipEnd {
+t.Errorf("raw 0xC0 found at inner byte %d in encoded data %X", i, encoded)
+}
+}
+}


### PR DESCRIPTION
This PR adds test coverage but it is limited to ~35% because the serial I/O, connection, and flashing paths require a real device. The tests cover all the pure logic and data-processing code that can be tested without hardware.

