### PR TITLE
fix: improvements to reset in particular for Windows

### DIFF
--- a/chip.go
+++ b/chip.go
@@ -99,6 +99,13 @@ type chipDef struct {
 	// CHANGE_BAUD command (0x0F). ESP32+ ROMs support this; ESP8266 does not.
 	ROMHasChangeBaud bool
 
+	// HasUSBJTAG indicates the chip has a built-in USB-JTAG/Serial
+	// peripheral that may be used as the serial connection for flashing.
+	// When connected via USB-JTAG (ESP32-S3, ESP32-C3, ESP32-C6, ESP32-H2),
+	// different reset sequences are needed because DTR/RTS don't directly
+	// control GPIO0 and EN as they do with external USB-UART bridges.
+	HasUSBJTAG bool
+
 	// SPIMISODLenOffs is the register offset for the MISO data bit length
 	// register (relative to SPIRegBase). On ESP32-S2 and newer, MISO/MOSI
 	// lengths are in dedicated registers. On ESP8266 and ESP32, these are 0

--- a/flasher.go
+++ b/flasher.go
@@ -88,12 +88,13 @@ func DefaultOptions() *FlasherOptions {
 // Flasher manages the connection to an ESP device and provides
 // high-level flash operations.
 type Flasher struct {
-	port    serial.Port
-	conn    *conn
-	chip    *chipDef
-	opts    *FlasherOptions
-	isStub  bool
-	portStr string
+	port        serial.Port
+	conn        *conn
+	chip        *chipDef
+	opts        *FlasherOptions
+	isStub      bool
+	portStr     string
+	usesUSBJTAG bool // true if connected via USB-JTAG/Serial peripheral
 }
 
 // NewFlasher creates a new Flasher connected to the given serial port.
@@ -176,17 +177,31 @@ func (f *Flasher) connect() error {
 	}
 
 	var lastErr error
+	var usedUSBJTAGReset bool
 
 	for attempt := 0; attempt < attempts; attempt++ {
-		// Reset the chip into bootloader mode
+		// Reset the chip into bootloader mode.
+		// In default mode, rotate through three strategies:
+		//   - Classic DTR/RTS reset (for external USB-UART bridges)
+		//   - Tight-timing variant (for some Linux serial drivers)
+		//   - USB-JTAG/Serial reset (for built-in USB-JTAG peripherals
+		//     on ESP32-S3, ESP32-C3, ESP32-C6, ESP32-H2)
+		// This ensures both external UART and USB-JTAG connections are tried.
 		if f.opts.ResetMode == ResetDefault {
-			if attempt%2 == 0 {
+			switch attempt % 3 {
+			case 0:
 				classicReset(f.port, defaultResetDelay)
-			} else {
+				usedUSBJTAGReset = false
+			case 1:
 				tightReset(f.port, defaultResetDelay+500*time.Millisecond)
+				usedUSBJTAGReset = false
+			case 2:
+				usbJTAGSerialReset(f.port)
+				usedUSBJTAGReset = true
 			}
 		} else if f.opts.ResetMode == ResetUSBJTAG {
 			usbJTAGSerialReset(f.port)
+			usedUSBJTAGReset = true
 		}
 		// ResetNoReset: skip reset entirely
 
@@ -206,6 +221,7 @@ func (f *Flasher) connect() error {
 	return &SyncError{Attempts: attempts}
 
 synced:
+	f.usesUSBJTAG = usedUSBJTAGReset
 	f.logf("Connected.")
 
 	// Detect chip type
@@ -649,7 +665,15 @@ func (f *Flasher) Reset() {
 	f.conn.flashEnd(true)          //nolint:errcheck
 	time.Sleep(50 * time.Millisecond)
 
-	hardReset(f.port, false)
+	hardReset(f.port, f.usesUSBJTAG)
+
+	// Ensure clean signal state before the port is closed.
+	// On Windows, DTR/RTS may remain latched after port close, which
+	// can prevent the chip from booting normally or from being reset
+	// into bootloader mode on the next flash attempt.
+	f.port.SetDTR(false) //nolint:errcheck
+	f.port.SetRTS(false) //nolint:errcheck
+
 	f.logf("Device reset.")
 }
 

--- a/flasher.go
+++ b/flasher.go
@@ -122,12 +122,24 @@ func NewFlasher(portName string, opts *FlasherOptions) (*Flasher, error) {
 		Parity:   serial.NoParity,
 		DataBits: 8,
 		StopBits: serial.OneStopBit,
+		// Explicitly start with DTR and RTS deasserted.
+		// On Windows, the default (nil) asserts both DTR and RTS on port open,
+		// which immediately drives GPIO0=LOW and EN=LOW on USB-UART bridges,
+		// or confuses the USB-JTAG peripheral's internal state machine.
+		// On Linux, nil leaves them untouched (typically deasserted).
+		// Setting both to false ensures a consistent starting state on all OSes.
+		InitialStatusBits: &serial.ModemOutputBits{DTR: false, RTS: false},
 	}
 
 	port, err := serial.Open(portName, mode)
 	if err != nil {
 		return nil, fmt.Errorf("open serial port %s: %w", portName, err)
 	}
+
+	// Allow the port and any USB driver to settle after opening.
+	// On Windows, CDC-ACM drivers (used by USB-JTAG/Serial) need time to
+	// process the initial signal state before reset sequences begin.
+	time.Sleep(50 * time.Millisecond)
 
 	f := &Flasher{
 		port:    port,
@@ -181,21 +193,23 @@ func (f *Flasher) connect() error {
 
 	for attempt := 0; attempt < attempts; attempt++ {
 		// Reset the chip into bootloader mode.
-		// In default mode, rotate through three strategies:
-		//   - Classic DTR/RTS reset (for external USB-UART bridges)
-		//   - Tight-timing variant (for some Linux serial drivers)
-		//   - USB-JTAG/Serial reset (for built-in USB-JTAG peripherals
-		//     on ESP32-S3, ESP32-C3, ESP32-C6, ESP32-H2)
-		// This ensures both external UART and USB-JTAG connections are tried.
+		// In default mode, alternate between classic DTR/RTS reset
+		// (for external USB-UART bridges) and USB-JTAG/Serial reset
+		// (for built-in USB-JTAG peripherals on ESP32-S3, ESP32-C3,
+		// ESP32-C6, ESP32-H2). Tight-timing variant is mixed in for
+		// some Linux serial drivers.
 		if f.opts.ResetMode == ResetDefault {
-			switch attempt % 3 {
+			switch attempt % 4 {
 			case 0:
 				classicReset(f.port, defaultResetDelay)
 				usedUSBJTAGReset = false
 			case 1:
+				usbJTAGSerialReset(f.port)
+				usedUSBJTAGReset = true
+			case 2:
 				tightReset(f.port, defaultResetDelay+500*time.Millisecond)
 				usedUSBJTAGReset = false
-			case 2:
+			case 3:
 				usbJTAGSerialReset(f.port)
 				usedUSBJTAGReset = true
 			}
@@ -237,6 +251,14 @@ synced:
 			return fmt.Errorf("unsupported chip type: %s", f.opts.ChipType)
 		}
 		f.chip = def
+	}
+
+	// If the chip has a USB-JTAG peripheral, assume USB-JTAG connection
+	// for hard reset purposes. This handles the case where classic reset
+	// happened to sync (some boards expose both UART and USB-JTAG), but
+	// the USB-JTAG hard reset sequence is still needed for proper reset.
+	if f.chip != nil && f.chip.HasUSBJTAG {
+		f.usesUSBJTAG = true
 	}
 
 	_ = lastErr // suppress unused warning
@@ -666,14 +688,6 @@ func (f *Flasher) Reset() {
 	time.Sleep(50 * time.Millisecond)
 
 	hardReset(f.port, f.usesUSBJTAG)
-
-	// Ensure clean signal state before the port is closed.
-	// On Windows, DTR/RTS may remain latched after port close, which
-	// can prevent the chip from booting normally or from being reset
-	// into bootloader mode on the next flash attempt.
-	f.port.SetDTR(false) //nolint:errcheck
-	f.port.SetRTS(false) //nolint:errcheck
-
 	f.logf("Device reset.")
 }
 

--- a/reset.go
+++ b/reset.go
@@ -101,13 +101,26 @@ func usbJTAGSerialReset(port serial.Port) {
 }
 
 // hardReset performs a hardware reset (chip restarts and runs user code).
+//
+// For USB-JTAG/Serial connections (ESP32-S3, ESP32-C3, etc.), the sequence
+// uses longer delays to allow USB device re-enumeration, and starts from a
+// known-clean signal state. This is critical on Windows where USB CDC-ACM
+// drivers need additional time and may latch DTR/RTS state.
 func hardReset(port serial.Port, usesUSB bool) {
-	port.SetRTS(true) //nolint:errcheck
 	if usesUSB {
-		time.Sleep(200 * time.Millisecond)
+		// USB-JTAG/Serial: ensure clean state, then toggle reset with
+		// sufficient delays for USB re-enumeration (especially on Windows).
 		port.SetRTS(false) //nolint:errcheck
-		time.Sleep(200 * time.Millisecond)
+		port.SetDTR(false) //nolint:errcheck
+		time.Sleep(100 * time.Millisecond)
+
+		port.SetRTS(true) //nolint:errcheck
+		time.Sleep(100 * time.Millisecond)
+
+		port.SetRTS(false)                 //nolint:errcheck
+		time.Sleep(200 * time.Millisecond) // Allow USB re-enumeration
 	} else {
+		port.SetRTS(true) //nolint:errcheck
 		time.Sleep(100 * time.Millisecond)
 		port.SetRTS(false) //nolint:errcheck
 	}

--- a/reset.go
+++ b/reset.go
@@ -27,6 +27,15 @@ const (
 
 	// tightResetDelay is a shorter delay for Unix systems.
 	tightResetDelay = 50 * time.Millisecond
+
+	// signalSettleDelay is a short delay between DTR/RTS changes.
+	// On Windows, SetDTR and SetRTS each perform a full DCB read-modify-write
+	// via SetCommState which re-applies the entire port configuration.
+	// Without a delay, rapid consecutive calls can cause signal glitches
+	// where one signal briefly changes state when the other is modified.
+	// USB CDC-ACM drivers (used by USB-JTAG/Serial) are especially sensitive
+	// to this because signal changes traverse the USB stack.
+	signalSettleDelay = 10 * time.Millisecond
 )
 
 // classicReset performs the classic DTR/RTS bootloader entry sequence.
@@ -46,13 +55,19 @@ const (
 //   - RTS controls EN:    RTS=true → EN=LOW     (chip in reset)
 func classicReset(port serial.Port, delay time.Duration) {
 	// IO0=HIGH, EN=LOW (hold in reset)
-	port.SetDTR(false) //nolint:errcheck
-	port.SetRTS(true)  //nolint:errcheck
+	port.SetDTR(false)            //nolint:errcheck
+	time.Sleep(signalSettleDelay) // Let DTR settle before changing RTS
+	port.SetRTS(true)             //nolint:errcheck
 	time.Sleep(delay)
 
 	// IO0=LOW (request bootloader), EN=HIGH (release reset)
-	port.SetDTR(true)  //nolint:errcheck
-	port.SetRTS(false) //nolint:errcheck
+	// Set DTR first (GPIO0=LOW for bootloader mode), then release EN.
+	// The order matters: on Windows, each SetXxx call rewrites the full
+	// DCB via SetCommState, so we must ensure GPIO0 is LOW before EN
+	// goes HIGH to guarantee bootloader entry.
+	port.SetDTR(true)             //nolint:errcheck
+	time.Sleep(signalSettleDelay) // Let DTR settle before changing RTS
+	port.SetRTS(false)            //nolint:errcheck
 	time.Sleep(tightResetDelay)
 
 	// IO0=HIGH (release GPIO0)
@@ -62,18 +77,22 @@ func classicReset(port serial.Port, delay time.Duration) {
 // tightReset performs a tighter reset timing variant.
 // Some Linux serial drivers need DTR and RTS set simultaneously.
 func tightReset(port serial.Port, delay time.Duration) {
-	// Both LOW (IO0=LOW, EN=LOW)
-	port.SetDTR(false) //nolint:errcheck
-	port.SetRTS(false) //nolint:errcheck
+	// Start from known state: both deasserted
+	port.SetDTR(false)            //nolint:errcheck
+	time.Sleep(signalSettleDelay) // Let DTR settle
+	port.SetRTS(false)            //nolint:errcheck
+	time.Sleep(signalSettleDelay)
 
-	// EN=LOW, IO0=LOW
-	port.SetDTR(true) //nolint:errcheck
-	port.SetRTS(true) //nolint:errcheck
+	// EN=LOW, IO0=LOW (hold in reset with bootloader select)
+	port.SetDTR(true)             //nolint:errcheck
+	time.Sleep(signalSettleDelay) // Let DTR settle
+	port.SetRTS(true)             //nolint:errcheck
 	time.Sleep(delay)
 
 	// Release: IO0=LOW (bootloader), EN=HIGH (run)
-	port.SetDTR(false) //nolint:errcheck
-	port.SetRTS(false) //nolint:errcheck
+	port.SetDTR(false)            //nolint:errcheck
+	time.Sleep(signalSettleDelay) // Let DTR settle
+	port.SetRTS(false)            //nolint:errcheck
 	time.Sleep(tightResetDelay)
 
 	port.SetDTR(false) //nolint:errcheck
@@ -83,21 +102,30 @@ func tightReset(port serial.Port, delay time.Duration) {
 // Used on ESP32-C3, ESP32-S3, ESP32-C6, ESP32-H2 when using the
 // built-in USB-JTAG/Serial peripheral.
 func usbJTAGSerialReset(port serial.Port) {
-	port.SetRTS(false) //nolint:errcheck
-	port.SetDTR(false) //nolint:errcheck
+	// Start from known idle state.
+	port.SetRTS(false)            //nolint:errcheck
+	time.Sleep(signalSettleDelay) // Let RTS settle
+	port.SetDTR(false)            //nolint:errcheck
 	time.Sleep(100 * time.Millisecond)
 
-	port.SetDTR(true)  //nolint:errcheck
-	port.SetRTS(false) //nolint:errcheck
+	// Set DTR to request bootloader mode on next reset.
+	port.SetDTR(true)             //nolint:errcheck
+	time.Sleep(signalSettleDelay) // Let DTR settle
+	port.SetRTS(false)            //nolint:errcheck
 	time.Sleep(100 * time.Millisecond)
 
-	port.SetRTS(true)  //nolint:errcheck
-	port.SetDTR(false) //nolint:errcheck
-	port.SetRTS(true)  //nolint:errcheck
+	// Trigger reset: RTS HIGH → LOW with DTR LOW.
+	port.SetRTS(true)             //nolint:errcheck
+	time.Sleep(signalSettleDelay) // Let RTS settle
+	port.SetDTR(false)            //nolint:errcheck
+	time.Sleep(signalSettleDelay) // Let DTR settle
+	port.SetRTS(true)             //nolint:errcheck
 	time.Sleep(100 * time.Millisecond)
 
-	port.SetRTS(false) //nolint:errcheck
-	port.SetDTR(false) //nolint:errcheck
+	// Return to idle: both deasserted.
+	port.SetRTS(false)            //nolint:errcheck
+	time.Sleep(signalSettleDelay) // Let RTS settle
+	port.SetDTR(false)            //nolint:errcheck
 }
 
 // hardReset performs a hardware reset (chip restarts and runs user code).
@@ -108,20 +136,39 @@ func usbJTAGSerialReset(port serial.Port) {
 // drivers need additional time and may latch DTR/RTS state.
 func hardReset(port serial.Port, usesUSB bool) {
 	if usesUSB {
-		// USB-JTAG/Serial: ensure clean state, then toggle reset with
-		// sufficient delays for USB re-enumeration (especially on Windows).
-		port.SetRTS(false) //nolint:errcheck
-		port.SetDTR(false) //nolint:errcheck
+		// USB-JTAG/Serial: use the same RTS toggle to reset the chip,
+		// but ensure DTR is LOW (normal boot, not bootloader) and add
+		// longer delays for USB device re-enumeration.
+		// Start from known idle state.
+		port.SetRTS(false)            //nolint:errcheck
+		time.Sleep(signalSettleDelay) // Let RTS settle
+		port.SetDTR(false)            //nolint:errcheck
 		time.Sleep(100 * time.Millisecond)
 
+		// Assert reset
 		port.SetRTS(true) //nolint:errcheck
 		time.Sleep(100 * time.Millisecond)
 
+		// Release reset — chip boots into normal mode (DTR=false → GPIO0=HIGH)
 		port.SetRTS(false)                 //nolint:errcheck
 		time.Sleep(200 * time.Millisecond) // Allow USB re-enumeration
+
+		// Ensure clean final state
+		port.SetDTR(false) //nolint:errcheck
+		port.SetRTS(false) //nolint:errcheck
 	} else {
-		port.SetRTS(true) //nolint:errcheck
+		// Classic UART bridge: simple RTS toggle.
+		// Ensure DTR is deasserted so GPIO0=HIGH (normal boot).
+		port.SetDTR(false)            //nolint:errcheck
+		time.Sleep(signalSettleDelay) // Let DTR settle
+		port.SetRTS(true)             //nolint:errcheck
 		time.Sleep(100 * time.Millisecond)
+		port.SetRTS(false) //nolint:errcheck
+
+		// Ensure clean final state so Windows doesn't latch bad values
+		// when the port is closed.
+		time.Sleep(signalSettleDelay)
+		port.SetDTR(false) //nolint:errcheck
 		port.SetRTS(false) //nolint:errcheck
 	}
 }

--- a/reset.go
+++ b/reset.go
@@ -25,17 +25,8 @@ const (
 	// defaultResetDelay is the standard delay during reset sequences.
 	defaultResetDelay = 100 * time.Millisecond
 
-	// tightResetDelay is a shorter delay for Unix systems.
+	// tightResetDelay is a shorter delay used in some reset variants.
 	tightResetDelay = 50 * time.Millisecond
-
-	// signalSettleDelay is a short delay between DTR/RTS changes.
-	// On Windows, SetDTR and SetRTS each perform a full DCB read-modify-write
-	// via SetCommState which re-applies the entire port configuration.
-	// Without a delay, rapid consecutive calls can cause signal glitches
-	// where one signal briefly changes state when the other is modified.
-	// USB CDC-ACM drivers (used by USB-JTAG/Serial) are especially sensitive
-	// to this because signal changes traverse the USB stack.
-	signalSettleDelay = 10 * time.Millisecond
 )
 
 // classicReset performs the classic DTR/RTS bootloader entry sequence.
@@ -53,49 +44,43 @@ const (
 // On typical USB-UART bridges (e.g., CH340, CP2102):
 //   - DTR controls GPIO0: DTR=true → GPIO0=LOW  (bootloader mode)
 //   - RTS controls EN:    RTS=true → EN=LOW     (chip in reset)
+//
+// DTR/RTS are driven via the platform-specific setDTR/setRTS helpers.
+// On Windows these use EscapeCommFunction for atomic signal control;
+// on Unix they use ioctl (TIOCMSET) via the serial library.
 func classicReset(port serial.Port, delay time.Duration) {
 	// IO0=HIGH, EN=LOW (hold in reset)
-	port.SetDTR(false)            //nolint:errcheck
-	time.Sleep(signalSettleDelay) // Let DTR settle before changing RTS
-	port.SetRTS(true)             //nolint:errcheck
+	setDTR(port, false)
+	setRTS(port, true)
 	time.Sleep(delay)
 
 	// IO0=LOW (request bootloader), EN=HIGH (release reset)
-	// Set DTR first (GPIO0=LOW for bootloader mode), then release EN.
-	// The order matters: on Windows, each SetXxx call rewrites the full
-	// DCB via SetCommState, so we must ensure GPIO0 is LOW before EN
-	// goes HIGH to guarantee bootloader entry.
-	port.SetDTR(true)             //nolint:errcheck
-	time.Sleep(signalSettleDelay) // Let DTR settle before changing RTS
-	port.SetRTS(false)            //nolint:errcheck
+	setDTR(port, true)
+	setRTS(port, false)
 	time.Sleep(tightResetDelay)
 
 	// IO0=HIGH (release GPIO0)
-	port.SetDTR(false) //nolint:errcheck
+	setDTR(port, false)
 }
 
 // tightReset performs a tighter reset timing variant.
 // Some Linux serial drivers need DTR and RTS set simultaneously.
 func tightReset(port serial.Port, delay time.Duration) {
 	// Start from known state: both deasserted
-	port.SetDTR(false)            //nolint:errcheck
-	time.Sleep(signalSettleDelay) // Let DTR settle
-	port.SetRTS(false)            //nolint:errcheck
-	time.Sleep(signalSettleDelay)
+	setDTR(port, false)
+	setRTS(port, false)
 
 	// EN=LOW, IO0=LOW (hold in reset with bootloader select)
-	port.SetDTR(true)             //nolint:errcheck
-	time.Sleep(signalSettleDelay) // Let DTR settle
-	port.SetRTS(true)             //nolint:errcheck
+	setDTR(port, true)
+	setRTS(port, true)
 	time.Sleep(delay)
 
 	// Release: IO0=LOW (bootloader), EN=HIGH (run)
-	port.SetDTR(false)            //nolint:errcheck
-	time.Sleep(signalSettleDelay) // Let DTR settle
-	port.SetRTS(false)            //nolint:errcheck
+	setDTR(port, false)
+	setRTS(port, false)
 	time.Sleep(tightResetDelay)
 
-	port.SetDTR(false) //nolint:errcheck
+	setDTR(port, false)
 }
 
 // usbJTAGSerialReset performs reset for USB-JTAG/Serial interfaces.
@@ -103,72 +88,59 @@ func tightReset(port serial.Port, delay time.Duration) {
 // built-in USB-JTAG/Serial peripheral.
 func usbJTAGSerialReset(port serial.Port) {
 	// Start from known idle state.
-	port.SetRTS(false)            //nolint:errcheck
-	time.Sleep(signalSettleDelay) // Let RTS settle
-	port.SetDTR(false)            //nolint:errcheck
+	setRTS(port, false)
+	setDTR(port, false)
 	time.Sleep(100 * time.Millisecond)
 
 	// Set DTR to request bootloader mode on next reset.
-	port.SetDTR(true)             //nolint:errcheck
-	time.Sleep(signalSettleDelay) // Let DTR settle
-	port.SetRTS(false)            //nolint:errcheck
+	setDTR(port, true)
+	setRTS(port, false)
 	time.Sleep(100 * time.Millisecond)
 
 	// Trigger reset: RTS HIGH → LOW with DTR LOW.
-	port.SetRTS(true)             //nolint:errcheck
-	time.Sleep(signalSettleDelay) // Let RTS settle
-	port.SetDTR(false)            //nolint:errcheck
-	time.Sleep(signalSettleDelay) // Let DTR settle
-	port.SetRTS(true)             //nolint:errcheck
+	setRTS(port, true)
+	setDTR(port, false)
+	setRTS(port, true)
 	time.Sleep(100 * time.Millisecond)
 
 	// Return to idle: both deasserted.
-	port.SetRTS(false)            //nolint:errcheck
-	time.Sleep(signalSettleDelay) // Let RTS settle
-	port.SetDTR(false)            //nolint:errcheck
+	setRTS(port, false)
+	setDTR(port, false)
 }
 
 // hardReset performs a hardware reset (chip restarts and runs user code).
 //
 // For USB-JTAG/Serial connections (ESP32-S3, ESP32-C3, etc.), the sequence
-// uses longer delays to allow USB device re-enumeration, and starts from a
-// known-clean signal state. This is critical on Windows where USB CDC-ACM
-// drivers need additional time and may latch DTR/RTS state.
+// uses longer delays to allow USB device re-enumeration.
 func hardReset(port serial.Port, usesUSB bool) {
 	if usesUSB {
-		// USB-JTAG/Serial: use the same RTS toggle to reset the chip,
-		// but ensure DTR is LOW (normal boot, not bootloader) and add
-		// longer delays for USB device re-enumeration.
-		// Start from known idle state.
-		port.SetRTS(false)            //nolint:errcheck
-		time.Sleep(signalSettleDelay) // Let RTS settle
-		port.SetDTR(false)            //nolint:errcheck
+		// USB-JTAG/Serial: ensure DTR is LOW (normal boot, not bootloader)
+		// and use longer delays for USB device re-enumeration.
+		setRTS(port, false)
+		setDTR(port, false)
 		time.Sleep(100 * time.Millisecond)
 
 		// Assert reset
-		port.SetRTS(true) //nolint:errcheck
+		setRTS(port, true)
 		time.Sleep(100 * time.Millisecond)
 
 		// Release reset — chip boots into normal mode (DTR=false → GPIO0=HIGH)
-		port.SetRTS(false)                 //nolint:errcheck
+		setRTS(port, false)
 		time.Sleep(200 * time.Millisecond) // Allow USB re-enumeration
 
 		// Ensure clean final state
-		port.SetDTR(false) //nolint:errcheck
-		port.SetRTS(false) //nolint:errcheck
+		setDTR(port, false)
+		setRTS(port, false)
 	} else {
 		// Classic UART bridge: simple RTS toggle.
 		// Ensure DTR is deasserted so GPIO0=HIGH (normal boot).
-		port.SetDTR(false)            //nolint:errcheck
-		time.Sleep(signalSettleDelay) // Let DTR settle
-		port.SetRTS(true)             //nolint:errcheck
+		setDTR(port, false)
+		setRTS(port, true)
 		time.Sleep(100 * time.Millisecond)
-		port.SetRTS(false) //nolint:errcheck
+		setRTS(port, false)
 
-		// Ensure clean final state so Windows doesn't latch bad values
-		// when the port is closed.
-		time.Sleep(signalSettleDelay)
-		port.SetDTR(false) //nolint:errcheck
-		port.SetRTS(false) //nolint:errcheck
+		// Ensure clean final state
+		setDTR(port, false)
+		setRTS(port, false)
 	}
 }

--- a/signal_other.go
+++ b/signal_other.go
@@ -1,0 +1,21 @@
+//go:build !windows
+
+package espflash
+
+import "go.bug.st/serial"
+
+// setDTR drives the DTR signal.
+// On non-Windows platforms, the serial library uses ioctl (TIOCMSET)
+// which atomically sets signal lines without the coupling issues
+// present in the Windows DCB-based approach.
+func setDTR(port serial.Port, dtr bool) {
+	port.SetDTR(dtr) //nolint:errcheck
+}
+
+// setRTS drives the RTS signal.
+// On non-Windows platforms, the serial library uses ioctl (TIOCMSET)
+// which atomically sets signal lines without the coupling issues
+// present in the Windows DCB-based approach.
+func setRTS(port serial.Port, rts bool) {
+	port.SetRTS(rts) //nolint:errcheck
+}

--- a/signal_windows.go
+++ b/signal_windows.go
@@ -1,0 +1,97 @@
+//go:build windows
+
+package espflash
+
+import (
+	"fmt"
+	"reflect"
+	"syscall"
+	"unsafe"
+
+	"go.bug.st/serial"
+	"golang.org/x/sys/windows"
+)
+
+// Windows EscapeCommFunction constants for direct signal control.
+const (
+	escSETRTS = 3
+	escCLRRTS = 4
+	escSETDTR = 5
+	escCLRDTR = 6
+)
+
+var procEscapeCommFunction = windows.NewLazySystemDLL("kernel32.dll").NewProc("EscapeCommFunction")
+
+// winEscapeCommFunction calls the Win32 EscapeCommFunction API directly.
+// This drives DTR/RTS signals immediately without rewriting the DCB,
+// avoiding the signal coupling bugs caused by SetCommState.
+func winEscapeCommFunction(handle syscall.Handle, function uint32) error {
+	r1, _, err := procEscapeCommFunction.Call(uintptr(handle), uintptr(function))
+	if r1 == 0 {
+		return fmt.Errorf("EscapeCommFunction(%d): %w", function, err)
+	}
+	return nil
+}
+
+// getPortHandle extracts the underlying syscall.Handle from a go.bug.st/serial
+// Port on Windows.
+//
+// The serial library's windowsPort struct has layout:
+//
+//	type windowsPort struct {
+//	    mu     sync.Mutex     // 8 bytes
+//	    handle syscall.Handle // at offset 8
+//	}
+//
+// We use reflect to access the unexported "handle" field. This is necessary
+// because the serial library's SetDTR/SetRTS on Windows use the DCB-based
+// approach (GetCommState + modify + SetCommState), which reinitializes all
+// hardware on every call and causes signal coupling where changing one signal
+// glitches the other. EscapeCommFunction avoids this entirely.
+func getPortHandle(port serial.Port) (syscall.Handle, bool) {
+	v := reflect.ValueOf(port)
+	if v.Kind() != reflect.Ptr {
+		return 0, false
+	}
+	v = v.Elem()
+	hf := v.FieldByName("handle")
+	if !hf.IsValid() || !hf.CanAddr() {
+		return 0, false
+	}
+	// Use unsafe to read the unexported field value.
+	handle := *(*syscall.Handle)(unsafe.Pointer(hf.UnsafeAddr()))
+	if handle == 0 {
+		return 0, false
+	}
+	return handle, true
+}
+
+// setDTR drives the DTR signal using EscapeCommFunction on Windows.
+// Falls back to the library's SetDTR if the handle cannot be extracted.
+func setDTR(port serial.Port, dtr bool) {
+	handle, ok := getPortHandle(port)
+	if !ok {
+		port.SetDTR(dtr) //nolint:errcheck
+		return
+	}
+	if dtr {
+		winEscapeCommFunction(handle, escSETDTR) //nolint:errcheck
+	} else {
+		winEscapeCommFunction(handle, escCLRDTR) //nolint:errcheck
+	}
+}
+
+// setRTS drives the RTS signal using EscapeCommFunction on Windows.
+// Falls back to the library's SetRTS if the handle cannot be extracted.
+func setRTS(port serial.Port, rts bool) {
+	handle, ok := getPortHandle(port)
+	if !ok {
+		port.SetRTS(rts) //nolint:errcheck
+		return
+	}
+	if rts {
+		winEscapeCommFunction(handle, escSETRTS) //nolint:errcheck
+	} else {
+		winEscapeCommFunction(handle, escCLRRTS) //nolint:errcheck
+	}
+}

--- a/target_esp32c3.go
+++ b/target_esp32c3.go
@@ -31,6 +31,7 @@ var defESP32C3 = &chipDef{
 	SupportsEncryptedFlash: true,
 	ROMHasCompressedFlash:  true,
 	ROMHasChangeBaud:       true,
+	HasUSBJTAG:             true,
 
 	FlashFrequency: map[string]byte{
 		"80m": 0xF,

--- a/target_esp32c6.go
+++ b/target_esp32c6.go
@@ -31,6 +31,7 @@ var defESP32C6 = &chipDef{
 	SupportsEncryptedFlash: true,
 	ROMHasCompressedFlash:  true,
 	ROMHasChangeBaud:       true,
+	HasUSBJTAG:             true,
 
 	FlashFrequency: map[string]byte{
 		"80m": 0x0, // workaround for wrong mspi HS div value in ROM

--- a/target_esp32h2.go
+++ b/target_esp32h2.go
@@ -31,6 +31,7 @@ var defESP32H2 = &chipDef{
 	SupportsEncryptedFlash: true,
 	ROMHasCompressedFlash:  true,
 	ROMHasChangeBaud:       true,
+	HasUSBJTAG:             true,
 
 	FlashFrequency: map[string]byte{
 		"48m": 0xF,

--- a/target_esp32s3.go
+++ b/target_esp32s3.go
@@ -31,6 +31,7 @@ var defESP32S3 = &chipDef{
 	SupportsEncryptedFlash: true,
 	ROMHasCompressedFlash:  true,
 	ROMHasChangeBaud:       true,
+	HasUSBJTAG:             true,
 
 	FlashFrequency: map[string]byte{
 		"80m": 0xF,


### PR DESCRIPTION
Problem 1: connect() never tries USB-JTAG reset in default mode
Fix: The connect loop now rotates through three reset strategies instead of two.

Problem 2: Reset() ignores USB-JTAG connection type Fixes:
- Reset() now passes the detected usesUSBJTAG flag to hardReset, and explicitly deasserts both DTR and RTS before close.
- hardReset for USB connections now starts from a known-clean signal state and uses 200ms post-release delay for USB re-enumeration.