### PR TITLE
all: rename project to espflasher

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2026, TinyGo
+Copyright The TinyGo Authors. All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# espflash
+# espflasher
 
-[![Test](https://github.com/tinygo-org/espflash/actions/workflows/test.yml/badge.svg)](https://github.com/tinygo-org/espflash/actions/workflows/test.yml)
+[![Test](https://github.com/tinygo-org/espflasher/actions/workflows/test.yml/badge.svg)](https://github.com/tinygo-org/espflasher/actions/workflows/test.yml)
 
 A Go command-line tool and library for flashing firmware to Espressif ESP8266 and ESP32-family microcontrollers over a serial (UART) connection.
 
@@ -22,29 +22,29 @@ A Go command-line tool and library for flashing firmware to Espressif ESP8266 an
 You can download and install one of the prebuilt binaries for your operating system under "Releases" or install from source:
 
 ```bash
-go install tinygo.org/x/espflash@latest
+go install tinygo.org/x/espflasher@latest
 ```
 
 ### CLI Usage
 
 ```bash
 # Install
-go install tinygo.org/x/espflash@latest
+go install tinygo.org/x/espflasher@latest
 
 # Flash a single binary
-espflash -port /dev/ttyUSB0 firmware.bin
+espflasher -port /dev/ttyUSB0 firmware.bin
 
 # Flash with specific offset and chip
-espflash -port /dev/ttyUSB0 -offset 0x10000 -chip esp32s3 app.bin
+espflasher -port /dev/ttyUSB0 -offset 0x10000 -chip esp32s3 app.bin
 
 # Flash multiple images (bootloader + partitions + app)
-espflash -port /dev/ttyUSB0 \
+espflasher -port /dev/ttyUSB0 \
     -bootloader bootloader.bin \
     -partitions partitions.bin \
     -app application.bin
 
 # Erase flash before writing
-espflash -port /dev/ttyUSB0 -erase-all firmware.bin
+espflasher -port /dev/ttyUSB0 -erase-all firmware.bin
 ```
 
 ## Library
@@ -52,7 +52,7 @@ espflash -port /dev/ttyUSB0 -erase-all firmware.bin
 ### Installation
 
 ```bash
-go get tinygo.org/x/espflash/pkg/espflash
+go get tinygo.org/x/espflasher/pkg/espflasher
 ```
 
 ### Quick Start
@@ -65,12 +65,12 @@ import (
     "log"
     "os"
 
-    "tinygo.org/x/espflash/pkg/espflash"
+    "tinygo.org/x/espflasher/pkg/espflasher"
 )
 
 func main() {
     // Connect to the ESP device
-    flasher, err := espflash.NewFlasher("/dev/ttyUSB0", nil)
+    flasher, err := espflasher.NewFlasher("/dev/ttyUSB0", nil)
     if err != nil {
         log.Fatal(err)
     }
@@ -115,14 +115,14 @@ func main() {
 
 ```go
 // With default options (115200 baud, auto-detect, compressed)
-flasher, err := espflash.NewFlasher("/dev/ttyUSB0", nil)
+flasher, err := espflasher.NewFlasher("/dev/ttyUSB0", nil)
 
 // With custom options
-opts := espflash.DefaultOptions()
+opts := espflasher.DefaultOptions()
 opts.FlashBaudRate = 921600
-opts.ChipType = espflash.ChipESP32S3
-opts.Logger = &espflash.StdoutLogger{W: os.Stdout}
-flasher, err := espflash.NewFlasher("/dev/ttyUSB0", opts)
+opts.ChipType = espflasher.ChipESP32S3
+opts.Logger = &espflasher.StdoutLogger{W: os.Stdout}
+flasher, err := espflasher.NewFlasher("/dev/ttyUSB0", opts)
 ```
 
 ### Flashing a Single Binary
@@ -135,7 +135,7 @@ err := flasher.FlashImage(data, 0x0, progressCallback)
 ### Flashing Multiple Images
 
 ```go
-images := []espflash.ImagePart{
+images := []espflasher.ImagePart{
     {Data: bootloaderBin, Offset: 0x1000},
     {Data: partitionsBin, Offset: 0x8000},
     {Data: applicationBin, Offset: 0x10000},
@@ -165,11 +165,11 @@ The library is organized in layers:
 
 | Layer | File(s) | Description |
 |-------|---------|-------------|
-| SLIP | `pkg/espflash/slip.go` | Serial Line Internet Protocol framing |
-| Protocol | `pkg/espflash/protocol.go` | ROM bootloader command/response protocol |
-| Chip | `pkg/espflash/chip.go`, `pkg/espflash/target_*.go` | Per-target definitions and detection |
-| Reset | `pkg/espflash/reset.go` | Hardware reset strategies |
-| Flasher | `pkg/espflash/flasher.go` | High-level flash/verify/reset API |
+| SLIP | `pkg/espflasher/slip.go` | Serial Line Internet Protocol framing |
+| Protocol | `pkg/espflasher/protocol.go` | ROM bootloader command/response protocol |
+| Chip | `pkg/espflasher/chip.go`, `pkg/espflasher/target_*.go` | Per-target definitions and detection |
+| Reset | `pkg/espflasher/reset.go` | Hardware reset strategies |
+| Flasher | `pkg/espflasher/flasher.go` | High-level flash/verify/reset API |
 | CLI | `main.go` | Command-line interface |
 
 ## Protocol Reference

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module tinygo.org/x/espflash
+module tinygo.org/x/espflasher
 
 go 1.22
 

--- a/main.go
+++ b/main.go
@@ -1,14 +1,14 @@
-// Command espflash flashes firmware to Espressif ESP8266 and ESP32-family
+// Command espflasher flashes firmware to Espressif ESP8266 and ESP32-family
 // microcontrollers over a serial (UART) connection.
 //
 // Install:
 //
-//	go install tinygo.org/x/espflash@latest
+//	go install tinygo.org/x/espflasher@latest
 //
 // Usage:
 //
-//	espflash -port /dev/ttyUSB0 -offset 0x0 firmware.bin
-//	espflash -port /dev/ttyUSB0 -bootloader bootloader.bin -partitions partitions.bin -app app.bin
+//	espflasher -port /dev/ttyUSB0 -offset 0x0 firmware.bin
+//	espflasher -port /dev/ttyUSB0 -bootloader bootloader.bin -partitions partitions.bin -app app.bin
 package main
 
 import (
@@ -19,7 +19,7 @@ import (
 	"strconv"
 	"strings"
 
-	"tinygo.org/x/espflash/pkg/espflash"
+	"tinygo.org/x/espflasher/pkg/espflasher"
 )
 
 func main() {
@@ -64,7 +64,7 @@ func main() {
 	flag.Parse()
 
 	if *version {
-		fmt.Printf("espflash %s\n", espflash.Version)
+		fmt.Printf("espflasher %s\n", espflasher.Version)
 		return
 	}
 
@@ -89,27 +89,27 @@ func main() {
 		os.Exit(1)
 	}
 
-	opts := espflash.DefaultOptions()
+	opts := espflasher.DefaultOptions()
 	opts.FlashBaudRate = *baud
 	opts.Compress = !*noCompress
-	opts.Logger = &espflash.StdoutLogger{W: os.Stdout}
+	opts.Logger = &espflasher.StdoutLogger{W: os.Stdout}
 	opts.ChipType = parseChipType(*chip)
 	opts.FlashMode = *flashMode
 	opts.FlashFreq = *flashFreq
 	opts.FlashSize = *flashSize
 	switch strings.ToLower(*resetMode) {
 	case "default":
-		opts.ResetMode = espflash.ResetDefault
+		opts.ResetMode = espflasher.ResetDefault
 	case "no-reset":
-		opts.ResetMode = espflash.ResetNoReset
+		opts.ResetMode = espflasher.ResetNoReset
 	case "usb-jtag":
-		opts.ResetMode = espflash.ResetUSBJTAG
+		opts.ResetMode = espflasher.ResetUSBJTAG
 	default:
 		log.Fatalf("Unknown reset mode: %s", *resetMode)
 	}
 
 	fmt.Printf("Connecting to %s...\n", *port)
-	flasher, err := espflash.NewFlasher(*port, opts)
+	flasher, err := espflasher.New(*port, opts)
 	if err != nil {
 		log.Fatalf("Failed to connect: %v", err)
 	}
@@ -148,7 +148,7 @@ func main() {
 			log.Fatalf("Flash failed: %v", err)
 		}
 	} else {
-		var images []espflash.ImagePart
+		var images []espflasher.ImagePart
 
 		if *bootloader != "" {
 			data, err := os.ReadFile(*bootloader)
@@ -160,7 +160,7 @@ func main() {
 				// Use chip-specific default
 				off = 0x1000 // Most common default
 			}
-			images = append(images, espflash.ImagePart{Data: data, Offset: off})
+			images = append(images, espflasher.ImagePart{Data: data, Offset: off})
 			fmt.Printf("Bootloader: %s (%d bytes) at 0x%08X\n", *bootloader, len(data), off)
 		}
 
@@ -170,7 +170,7 @@ func main() {
 				log.Fatalf("Read partitions: %v", err)
 			}
 			off := parseHex(*partitionsOffset)
-			images = append(images, espflash.ImagePart{Data: data, Offset: off})
+			images = append(images, espflasher.ImagePart{Data: data, Offset: off})
 			fmt.Printf("Partitions: %s (%d bytes) at 0x%08X\n", *partitions, len(data), off)
 		}
 
@@ -180,7 +180,7 @@ func main() {
 				log.Fatalf("Read app: %v", err)
 			}
 			off := parseHex(*appOffset)
-			images = append(images, espflash.ImagePart{Data: data, Offset: off})
+			images = append(images, espflasher.ImagePart{Data: data, Offset: off})
 			fmt.Printf("App: %s (%d bytes) at 0x%08X\n", *app, len(data), off)
 		}
 
@@ -207,29 +207,29 @@ func parseHex(s string) uint32 {
 	return uint32(val)
 }
 
-func parseChipType(s string) espflash.ChipType {
+func parseChipType(s string) espflasher.ChipType {
 	switch strings.ToLower(s) {
 	case "auto":
-		return espflash.ChipAuto
+		return espflasher.ChipAuto
 	case "esp8266":
-		return espflash.ChipESP8266
+		return espflasher.ChipESP8266
 	case "esp32":
-		return espflash.ChipESP32
+		return espflasher.ChipESP32
 	case "esp32s2", "esp32-s2":
-		return espflash.ChipESP32S2
+		return espflasher.ChipESP32S2
 	case "esp32s3", "esp32-s3":
-		return espflash.ChipESP32S3
+		return espflasher.ChipESP32S3
 	case "esp32c2", "esp32-c2":
-		return espflash.ChipESP32C2
+		return espflasher.ChipESP32C2
 	case "esp32c3", "esp32-c3":
-		return espflash.ChipESP32C3
+		return espflasher.ChipESP32C3
 	case "esp32c6", "esp32-c6":
-		return espflash.ChipESP32C6
+		return espflasher.ChipESP32C6
 	case "esp32h2", "esp32-h2":
-		return espflash.ChipESP32H2
+		return espflasher.ChipESP32H2
 	default:
 		log.Fatalf("Unknown chip type: %s", s)
-		return espflash.ChipAuto
+		return espflasher.ChipAuto
 	}
 }
 
@@ -237,7 +237,7 @@ func parseChipType(s string) espflash.ChipType {
 // a flag) to the end of os.Args so that Go's flag package can parse all flags
 // regardless of where they appear on the command line. This lets users write:
 //
-//	espflash -port COM3 firmware.bin -fm dout
+//	espflasher -port COM3 firmware.bin -fm dout
 //
 // instead of requiring all flags before the positional argument.
 func reorderArgs() {

--- a/pkg/espflash/version.go
+++ b/pkg/espflash/version.go
@@ -1,4 +1,0 @@
-package espflash
-
-// Version is the current version of the espflash library.
-const Version = "0.3.1"

--- a/pkg/espflasher/chip.go
+++ b/pkg/espflasher/chip.go
@@ -1,4 +1,4 @@
-package espflash
+package espflasher
 
 import "fmt"
 

--- a/pkg/espflasher/chip_test.go
+++ b/pkg/espflasher/chip_test.go
@@ -1,4 +1,4 @@
-package espflash
+package espflasher
 
 import (
 	"testing"

--- a/pkg/espflasher/doc.go
+++ b/pkg/espflasher/doc.go
@@ -1,4 +1,4 @@
-// Package espflash provides a Go library for flashing firmware to Espressif
+// Package espflasher provides a Go library for flashing firmware to Espressif
 // ESP8266 and ESP32-family microcontrollers over a serial (UART) connection.
 // It implements the serial bootloader protocol used by the ESP ROM bootloader,
 // supporting the following chip families:
@@ -16,7 +16,7 @@
 //
 // To flash a .bin file to a connected ESP device:
 //
-//	flasher, err := espflash.NewFlasher("/dev/ttyUSB0", nil)
+//	flasher, err := espflasher.NewFlasher("/dev/ttyUSB0", nil)
 //	if err != nil {
 //	    log.Fatal(err)
 //	}
@@ -41,4 +41,4 @@
 // The protocol uses SLIP framing over serial UART. Commands are sent as
 // request packets with an opcode, and the device responds with status.
 // Flash writes can optionally use zlib-compressed data for faster transfers.
-package espflash
+package espflasher

--- a/pkg/espflasher/errors.go
+++ b/pkg/espflasher/errors.go
@@ -1,4 +1,4 @@
-package espflash
+package espflasher
 
 import "fmt"
 

--- a/pkg/espflasher/errors_test.go
+++ b/pkg/espflasher/errors_test.go
@@ -1,4 +1,4 @@
-package espflash
+package espflasher
 
 import (
 	"strings"

--- a/pkg/espflasher/flasher.go
+++ b/pkg/espflasher/flasher.go
@@ -1,4 +1,4 @@
-package espflash
+package espflasher
 
 import (
 	"bytes"
@@ -96,7 +96,7 @@ type Flasher struct {
 	portStr string
 }
 
-// NewFlasher creates a new Flasher connected to the given serial port.
+// New creates a new Flasher connected to the given serial port.
 //
 // It opens the serial port, enters the bootloader, syncs with the device,
 // and detects the chip type. On success, the Flasher is ready for flash
@@ -106,12 +106,12 @@ type Flasher struct {
 //
 // Example:
 //
-//	f, err := espflash.NewFlasher("/dev/ttyUSB0", nil)
+//	f, err := espflasher.New("/dev/ttyUSB0", nil)
 //	if err != nil {
 //	    log.Fatal(err)
 //	}
 //	defer f.Close()
-func NewFlasher(portName string, opts *FlasherOptions) (*Flasher, error) {
+func New(portName string, opts *FlasherOptions) (*Flasher, error) {
 	if opts == nil {
 		opts = DefaultOptions()
 	}
@@ -355,7 +355,7 @@ func (f *Flasher) FlashImage(data []byte, offset uint32, progress ProgressFunc) 
 //
 // Example:
 //
-//	images := []espflash.ImagePart{
+//	images := []espflasher.ImagePart{
 //	    {Data: bootloader, Offset: 0x1000},
 //	    {Data: partTable, Offset: 0x8000},
 //	    {Data: app, Offset: 0x10000},

--- a/pkg/espflasher/flasher_test.go
+++ b/pkg/espflasher/flasher_test.go
@@ -1,4 +1,4 @@
-package espflash
+package espflasher
 
 import (
 	"bytes"

--- a/pkg/espflasher/image.go
+++ b/pkg/espflasher/image.go
@@ -1,4 +1,4 @@
-package espflash
+package espflasher
 
 import (
 	"crypto/sha256"

--- a/pkg/espflasher/image_test.go
+++ b/pkg/espflasher/image_test.go
@@ -1,4 +1,4 @@
-package espflash
+package espflasher
 
 import (
 	"crypto/sha256"

--- a/pkg/espflasher/protocol.go
+++ b/pkg/espflasher/protocol.go
@@ -1,4 +1,4 @@
-package espflash
+package espflasher
 
 import (
 	"encoding/binary"

--- a/pkg/espflasher/protocol_test.go
+++ b/pkg/espflasher/protocol_test.go
@@ -1,4 +1,4 @@
-package espflash
+package espflasher
 
 import (
 	"encoding/binary"

--- a/pkg/espflasher/reset.go
+++ b/pkg/espflasher/reset.go
@@ -1,4 +1,4 @@
-package espflash
+package espflasher
 
 import (
 	"time"

--- a/pkg/espflasher/slip.go
+++ b/pkg/espflasher/slip.go
@@ -1,4 +1,4 @@
-package espflash
+package espflasher
 
 import (
 	"bytes"

--- a/pkg/espflasher/slip_test.go
+++ b/pkg/espflasher/slip_test.go
@@ -1,4 +1,4 @@
-package espflash
+package espflasher
 
 import (
 "bytes"

--- a/pkg/espflasher/target_esp32.go
+++ b/pkg/espflasher/target_esp32.go
@@ -1,4 +1,4 @@
-package espflash
+package espflasher
 
 // ESP32 target definition.
 // Reference: https://github.com/espressif/esptool/blob/master/esptool/targets/esp32.py

--- a/pkg/espflasher/target_esp32c2.go
+++ b/pkg/espflasher/target_esp32c2.go
@@ -1,13 +1,13 @@
-package espflash
+package espflasher
 
-// ESP32-S3 target definition.
-// Reference: https://github.com/espressif/esptool/blob/master/esptool/targets/esp32s3.py
+// ESP32-C2 (ESP8684) target definition.
+// Reference: https://github.com/espressif/esptool/blob/master/esptool/targets/esp32c2.py
 
-var defESP32S3 = &chipDef{
-	ChipType:       ChipESP32S3,
-	Name:           "ESP32-S3",
-	ImageChipID:    9,
-	UsesMagicValue: false, // Uses chip ID, not magic value
+var defESP32C2 = &chipDef{
+	ChipType:       ChipESP32C2,
+	Name:           "ESP32-C2",
+	ImageChipID:    12,
+	UsesMagicValue: false, // Uses chip ID
 
 	SPIRegBase:  0x60002000,
 	SPIUSROffs:  0x18,
@@ -33,9 +33,10 @@ var defESP32S3 = &chipDef{
 	ROMHasChangeBaud:       true,
 
 	FlashFrequency: map[string]byte{
-		"80m": 0xF,
-		"40m": 0x0,
-		"20m": 0x2,
+		"60m": 0xF,
+		"30m": 0x0,
+		"20m": 0x1,
+		"15m": 0x2,
 	},
 
 	FlashSizes: defaultFlashSizes(),

--- a/pkg/espflasher/target_esp32c3.go
+++ b/pkg/espflasher/target_esp32c3.go
@@ -1,16 +1,15 @@
-package espflash
+package espflasher
 
-// ESP32-S2 target definition.
-// Reference: https://github.com/espressif/esptool/blob/master/esptool/targets/esp32s2.py
+// ESP32-C3 target definition.
+// Reference: https://github.com/espressif/esptool/blob/master/esptool/targets/esp32c3.py
 
-var defESP32S2 = &chipDef{
-	ChipType:       ChipESP32S2,
-	Name:           "ESP32-S2",
-	MagicValue:     0x000007C6,
-	ImageChipID:    2,
-	UsesMagicValue: true,
+var defESP32C3 = &chipDef{
+	ChipType:       ChipESP32C3,
+	Name:           "ESP32-C3",
+	ImageChipID:    5,
+	UsesMagicValue: false, // Uses chip ID
 
-	SPIRegBase:  0x3F402000,
+	SPIRegBase:  0x60002000,
 	SPIUSROffs:  0x18,
 	SPIUSR1Offs: 0x1C,
 	SPIUSR2Offs: 0x20,
@@ -24,10 +23,10 @@ var defESP32S2 = &chipDef{
 	SPIAddrRegMSB: true,
 
 	UARTDateReg: 0x60000078,
-	UARTClkDiv:  0x3F400014,
+	UARTClkDiv:  0x60000014,
 	XTALClkDiv:  1,
 
-	BootloaderFlashOffset: 0x1000,
+	BootloaderFlashOffset: 0x0,
 
 	SupportsEncryptedFlash: true,
 	ROMHasCompressedFlash:  true,
@@ -36,7 +35,6 @@ var defESP32S2 = &chipDef{
 	FlashFrequency: map[string]byte{
 		"80m": 0xF,
 		"40m": 0x0,
-		"26m": 0x1,
 		"20m": 0x2,
 	},
 

--- a/pkg/espflasher/target_esp32c6.go
+++ b/pkg/espflasher/target_esp32c6.go
@@ -1,15 +1,15 @@
-package espflash
+package espflasher
 
-// ESP32-C3 target definition.
-// Reference: https://github.com/espressif/esptool/blob/master/esptool/targets/esp32c3.py
+// ESP32-C6 target definition.
+// Reference: https://github.com/espressif/esptool/blob/master/esptool/targets/esp32c6.py
 
-var defESP32C3 = &chipDef{
-	ChipType:       ChipESP32C3,
-	Name:           "ESP32-C3",
-	ImageChipID:    5,
+var defESP32C6 = &chipDef{
+	ChipType:       ChipESP32C6,
+	Name:           "ESP32-C6",
+	ImageChipID:    13,
 	UsesMagicValue: false, // Uses chip ID
 
-	SPIRegBase:  0x60002000,
+	SPIRegBase:  0x60003000,
 	SPIUSROffs:  0x18,
 	SPIUSR1Offs: 0x1C,
 	SPIUSR2Offs: 0x20,
@@ -33,7 +33,7 @@ var defESP32C3 = &chipDef{
 	ROMHasChangeBaud:       true,
 
 	FlashFrequency: map[string]byte{
-		"80m": 0xF,
+		"80m": 0x0, // workaround for wrong mspi HS div value in ROM
 		"40m": 0x0,
 		"20m": 0x2,
 	},

--- a/pkg/espflasher/target_esp32h2.go
+++ b/pkg/espflasher/target_esp32h2.go
@@ -1,12 +1,12 @@
-package espflash
+package espflasher
 
-// ESP32-C2 (ESP8684) target definition.
-// Reference: https://github.com/espressif/esptool/blob/master/esptool/targets/esp32c2.py
+// ESP32-H2 target definition.
+// Reference: https://github.com/espressif/esptool/blob/master/esptool/targets/esp32h2.py
 
-var defESP32C2 = &chipDef{
-	ChipType:       ChipESP32C2,
-	Name:           "ESP32-C2",
-	ImageChipID:    12,
+var defESP32H2 = &chipDef{
+	ChipType:       ChipESP32H2,
+	Name:           "ESP32-H2",
+	ImageChipID:    16,
 	UsesMagicValue: false, // Uses chip ID
 
 	SPIRegBase:  0x60002000,
@@ -33,10 +33,10 @@ var defESP32C2 = &chipDef{
 	ROMHasChangeBaud:       true,
 
 	FlashFrequency: map[string]byte{
-		"60m": 0xF,
-		"30m": 0x0,
-		"20m": 0x1,
-		"15m": 0x2,
+		"48m": 0xF,
+		"24m": 0x0,
+		"16m": 0x1,
+		"12m": 0x2,
 	},
 
 	FlashSizes: defaultFlashSizes(),

--- a/pkg/espflasher/target_esp32s2.go
+++ b/pkg/espflasher/target_esp32s2.go
@@ -1,15 +1,16 @@
-package espflash
+package espflasher
 
-// ESP32-C6 target definition.
-// Reference: https://github.com/espressif/esptool/blob/master/esptool/targets/esp32c6.py
+// ESP32-S2 target definition.
+// Reference: https://github.com/espressif/esptool/blob/master/esptool/targets/esp32s2.py
 
-var defESP32C6 = &chipDef{
-	ChipType:       ChipESP32C6,
-	Name:           "ESP32-C6",
-	ImageChipID:    13,
-	UsesMagicValue: false, // Uses chip ID
+var defESP32S2 = &chipDef{
+	ChipType:       ChipESP32S2,
+	Name:           "ESP32-S2",
+	MagicValue:     0x000007C6,
+	ImageChipID:    2,
+	UsesMagicValue: true,
 
-	SPIRegBase:  0x60003000,
+	SPIRegBase:  0x3F402000,
 	SPIUSROffs:  0x18,
 	SPIUSR1Offs: 0x1C,
 	SPIUSR2Offs: 0x20,
@@ -23,18 +24,19 @@ var defESP32C6 = &chipDef{
 	SPIAddrRegMSB: true,
 
 	UARTDateReg: 0x60000078,
-	UARTClkDiv:  0x60000014,
+	UARTClkDiv:  0x3F400014,
 	XTALClkDiv:  1,
 
-	BootloaderFlashOffset: 0x0,
+	BootloaderFlashOffset: 0x1000,
 
 	SupportsEncryptedFlash: true,
 	ROMHasCompressedFlash:  true,
 	ROMHasChangeBaud:       true,
 
 	FlashFrequency: map[string]byte{
-		"80m": 0x0, // workaround for wrong mspi HS div value in ROM
+		"80m": 0xF,
 		"40m": 0x0,
+		"26m": 0x1,
 		"20m": 0x2,
 	},
 

--- a/pkg/espflasher/target_esp32s3.go
+++ b/pkg/espflasher/target_esp32s3.go
@@ -1,13 +1,13 @@
-package espflash
+package espflasher
 
-// ESP32-H2 target definition.
-// Reference: https://github.com/espressif/esptool/blob/master/esptool/targets/esp32h2.py
+// ESP32-S3 target definition.
+// Reference: https://github.com/espressif/esptool/blob/master/esptool/targets/esp32s3.py
 
-var defESP32H2 = &chipDef{
-	ChipType:       ChipESP32H2,
-	Name:           "ESP32-H2",
-	ImageChipID:    16,
-	UsesMagicValue: false, // Uses chip ID
+var defESP32S3 = &chipDef{
+	ChipType:       ChipESP32S3,
+	Name:           "ESP32-S3",
+	ImageChipID:    9,
+	UsesMagicValue: false, // Uses chip ID, not magic value
 
 	SPIRegBase:  0x60002000,
 	SPIUSROffs:  0x18,
@@ -33,10 +33,9 @@ var defESP32H2 = &chipDef{
 	ROMHasChangeBaud:       true,
 
 	FlashFrequency: map[string]byte{
-		"48m": 0xF,
-		"24m": 0x0,
-		"16m": 0x1,
-		"12m": 0x2,
+		"80m": 0xF,
+		"40m": 0x0,
+		"20m": 0x2,
 	},
 
 	FlashSizes: defaultFlashSizes(),

--- a/pkg/espflasher/target_esp8266.go
+++ b/pkg/espflasher/target_esp8266.go
@@ -1,4 +1,4 @@
-package espflash
+package espflasher
 
 // ESP8266 target definition.
 // Reference: https://github.com/espressif/esptool/blob/master/esptool/targets/esp8266.py

--- a/pkg/espflasher/version.go
+++ b/pkg/espflasher/version.go
@@ -1,0 +1,4 @@
+package espflasher
+
+// Version is the current version of the espflasher library.
+const Version = "0.4.0-dev"


### PR DESCRIPTION
This PR is to rename the project to `espflasher` to avoid confusion. 'nuff said!