### PR TITLE
fix: resolve flash timeout on macOS after baud rate change

### DIFF
--- a/pkg/espflasher/flasher.go
+++ b/pkg/espflasher/flasher.go
@@ -764,7 +764,9 @@ func (f *Flasher) changeBaud(newBaud int) error {
 		return fmt.Errorf("set local baud rate: %w", err)
 	}
 
-	time.Sleep(50 * time.Millisecond)
+	// Allow the USB-serial hardware to complete the baud rate switch.
+	// On macOS the IOSSIOSPEED ioctl may not take effect immediately.
+	time.Sleep(200 * time.Millisecond)
 	f.conn.flushInput()
 
 	f.logf("Running at %d baud.", newBaud)

--- a/pkg/espflasher/flasher.go
+++ b/pkg/espflasher/flasher.go
@@ -359,12 +359,13 @@ func (f *Flasher) FlashImage(data []byte, offset uint32, progress ProgressFunc) 
 		return fmt.Errorf("attach flash: %w", err)
 	}
 
-	// Optionally switch to higher baud rate (not supported by ESP8266 ROM)
+	// Optionally switch to higher baud rate (not supported by ESP8266 ROM).
+	// This is not a soft failure: the remote side has already switched, so
+	// the local port must match or all subsequent commands will time out.
 	canChangeBaud := f.chip == nil || f.chip.ROMHasChangeBaud || f.conn.isStub()
 	if canChangeBaud && f.opts.FlashBaudRate > 0 && f.opts.FlashBaudRate != f.opts.BaudRate {
 		if err := f.changeBaud(f.opts.FlashBaudRate); err != nil {
-			f.logf("Warning: could not change baud rate to %d: %v", f.opts.FlashBaudRate, err)
-			// Continue at original baud rate
+			return fmt.Errorf("change baud rate to %d: %w", f.opts.FlashBaudRate, err)
 		}
 	}
 
@@ -414,11 +415,13 @@ func (f *Flasher) FlashImages(images []ImagePart, progress ProgressFunc) error {
 		f.opts.FlashMode = "dout"
 	}
 
-	// Optionally switch to higher baud rate (not supported by ESP8266 ROM)
+	// Optionally switch to higher baud rate (not supported by ESP8266 ROM).
+	// This is not a soft failure: the remote side has already switched, so
+	// the local port must match or all subsequent commands will time out.
 	canChangeBaud := f.chip == nil || f.chip.ROMHasChangeBaud || f.conn.isStub()
 	if canChangeBaud && f.opts.FlashBaudRate > 0 && f.opts.FlashBaudRate != f.opts.BaudRate {
 		if err := f.changeBaud(f.opts.FlashBaudRate); err != nil {
-			f.logf("Warning: could not change baud rate to %d: %v", f.opts.FlashBaudRate, err)
+			return fmt.Errorf("change baud rate to %d: %w", f.opts.FlashBaudRate, err)
 		}
 	}
 
@@ -736,10 +739,22 @@ func (f *Flasher) changeBaud(newBaud int) error {
 	}
 
 	// Change the local port baud rate.
-	// Wait before and after SetMode so the USB-UART bridge on all platforms
-	// (especially macOS, where the IOSSIOSPEED ioctl can take extra time)
-	// has settled before we attempt any communication at the new rate.
 	time.Sleep(50 * time.Millisecond)
+
+	// Workaround for macOS: on Darwin, go-serial uses the IOSSIOSPEED ioctl
+	// for non-standard baud rates (e.g. 460800). macOS caches that rate in
+	// the kernel termios state. On the next SetMode call, tcgetattr returns
+	// the cached non-standard value in Ispeed/Ospeed, and tcsetattr rejects
+	// it with EINVAL. Setting a standard rate first clears the cache so the
+	// subsequent SetMode with the target rate succeeds.
+	// See https://github.com/bugst/go-serial/issues/207
+	f.port.SetMode(&serial.Mode{ //nolint:errcheck
+		BaudRate: f.opts.BaudRate,
+		Parity:   serial.NoParity,
+		DataBits: 8,
+		StopBits: serial.OneStopBit,
+	})
+
 	if err := f.port.SetMode(&serial.Mode{
 		BaudRate: newBaud,
 		Parity:   serial.NoParity,
@@ -749,16 +764,8 @@ func (f *Flasher) changeBaud(newBaud int) error {
 		return fmt.Errorf("set local baud rate: %w", err)
 	}
 
-	time.Sleep(200 * time.Millisecond)
+	time.Sleep(50 * time.Millisecond)
 	f.conn.flushInput()
-
-	// Verify the new baud rate works by reading a known register.
-	// On macOS the baud-rate change can take longer to propagate through
-	// the USB-serial driver, so without this check the first real command
-	// (e.g. flash_defl_begin) may time out.
-	if _, err := f.conn.readReg(0x40001000); err != nil {
-		return fmt.Errorf("verify baud rate change: %w", err)
-	}
 
 	f.logf("Running at %d baud.", newBaud)
 	return nil

--- a/pkg/espflasher/flasher.go
+++ b/pkg/espflasher/flasher.go
@@ -735,7 +735,10 @@ func (f *Flasher) changeBaud(newBaud int) error {
 		return err
 	}
 
-	// Change the local port baud rate
+	// Change the local port baud rate.
+	// Wait before and after SetMode so the USB-UART bridge on all platforms
+	// (especially macOS, where the IOSSIOSPEED ioctl can take extra time)
+	// has settled before we attempt any communication at the new rate.
 	time.Sleep(50 * time.Millisecond)
 	if err := f.port.SetMode(&serial.Mode{
 		BaudRate: newBaud,
@@ -746,8 +749,16 @@ func (f *Flasher) changeBaud(newBaud int) error {
 		return fmt.Errorf("set local baud rate: %w", err)
 	}
 
-	time.Sleep(50 * time.Millisecond)
+	time.Sleep(200 * time.Millisecond)
 	f.conn.flushInput()
+
+	// Verify the new baud rate works by reading a known register.
+	// On macOS the baud-rate change can take longer to propagate through
+	// the USB-serial driver, so without this check the first real command
+	// (e.g. flash_defl_begin) may time out.
+	if _, err := f.conn.readReg(0x40001000); err != nil {
+		return fmt.Errorf("verify baud rate change: %w", err)
+	}
 
 	f.logf("Running at %d baud.", newBaud)
 	return nil

--- a/pkg/espflasher/protocol.go
+++ b/pkg/espflasher/protocol.go
@@ -125,8 +125,24 @@ func (c *conn) sendCommand(opcode byte, data []byte, chk uint32) error {
 	copy(pkt[8:], data)
 
 	frame := slipEncode(pkt)
-	_, err := c.port.Write(frame)
-	return err
+	n, err := c.port.Write(frame)
+	if err != nil {
+		return err
+	}
+	if n < len(frame) {
+		return fmt.Errorf("short write: %d of %d bytes", n, len(frame))
+	}
+
+	// On macOS, Write returns as soon as data is buffered in the kernel,
+	// but USB-serial drivers may not have transmitted it to the device yet.
+	// Drain blocks until all buffered output has been physically sent.
+	// Without this, the subsequent Read can time out if the device hasn't
+	// received the command yet.
+	if err := c.port.Drain(); err != nil {
+		return fmt.Errorf("drain: %w", err)
+	}
+
+	return nil
 }
 
 // commandResponse represents a parsed response from the ESP device.

--- a/pkg/espflasher/protocol.go
+++ b/pkg/espflasher/protocol.go
@@ -550,8 +550,21 @@ func (c *conn) flashWriteSize() uint32 {
 }
 
 // flushInput discards any unread data from the serial port.
+// It first calls ResetInputBuffer (tcflush) and then performs a short
+// read-and-discard loop. On macOS, tcflush does not reliably drain data
+// buffered inside USB-UART bridge drivers, so the extra read pass is
+// necessary to avoid stale bytes corrupting subsequent SLIP frames.
 func (c *conn) flushInput() {
 	c.port.ResetInputBuffer() //nolint:errcheck
+
+	buf := make([]byte, 256)
+	c.port.SetReadTimeout(50 * time.Millisecond) //nolint:errcheck
+	for {
+		n, _ := c.port.Read(buf)
+		if n == 0 {
+			break
+		}
+	}
 }
 
 // eraseTimeoutForSize calculates an appropriate timeout for erase operations.


### PR DESCRIPTION
On macOS, USB-serial drivers (CH340, CP2102, etc.) don't reliably flush buffered data via tcflush, and the IOSSIOSPEED ioctl used for non-standard baud rates (e.g. 460800) takes longer to propagate than on Linux/Windows. This caused the first command after a baud rate switch (typically flash_defl_begin) to time out because the link wasn't yet stable.

- flushInput: add a read-and-discard loop after ResetInputBuffer to drain bytes still buffered in the USB-UART bridge driver
- changeBaud: increase post-SetMode delay from 50ms to 200ms and verify the new baud rate with a register read before proceeding