### PR TITLE
feat: add ESP32-S3 USB PostConnect with watchdog disable

### DIFF
--- a/pkg/espflasher/target_esp32s3.go
+++ b/pkg/espflasher/target_esp32s3.go
@@ -1,5 +1,24 @@
 package espflasher
 
+import "fmt"
+
+// ESP32-S3 register addresses for USB interface detection and watchdog control.
+// Reference: esptool/targets/esp32s3.py
+const (
+	esp32s3UARTDevBufNo              uint32 = 0x3FCEF14C // ROM .bss: active console interface
+	esp32s3UARTDevBufNoUSBOTG        uint32 = 3          // USB-OTG (CDC) active
+	esp32s3UARTDevBufNoUSBJTAGSerial uint32 = 4          // USB-JTAG/Serial active
+
+	esp32s3RTCCntlWDTConfig0  uint32 = 0x60008098
+	esp32s3RTCCntlWDTWProtect uint32 = 0x600080B0
+	esp32s3RTCCntlWDTWKey     uint32 = 0x50D83AA1
+
+	esp32s3RTCCntlSWDConf       uint32 = 0x600080B4
+	esp32s3RTCCntlSWDAutoFeedEn uint32 = 1 << 31
+	esp32s3RTCCntlSWDWProtect   uint32 = 0x600080B8
+	esp32s3RTCCntlSWDWKey       uint32 = 0x8F1D312A
+)
+
 // ESP32-S3 target definition.
 // Reference: https://github.com/espressif/esptool/blob/master/esptool/targets/esp32s3.py
 
@@ -39,4 +58,68 @@ var defESP32S3 = &chipDef{
 	},
 
 	FlashSizes: defaultFlashSizes(),
+
+	PostConnect: esp32s3PostConnect,
+}
+
+// esp32s3PostConnect detects the USB interface type and disables watchdogs
+// when connected via USB-JTAG/Serial. Without this, the RTC WDT fires
+// during flash and resets the chip mid-operation.
+// Reference: esptool/targets/esp32s3.py _post_connect()
+func esp32s3PostConnect(f *Flasher) error {
+	val, err := f.conn.readReg(esp32s3UARTDevBufNo)
+	if err != nil {
+		// In secure download mode, the register may be unreadable.
+		// Default to non-USB behavior (safe fallback).
+		return nil
+	}
+
+	switch val {
+	case esp32s3UARTDevBufNoUSBJTAGSerial:
+		f.usesUSB = true
+		f.logf("USB-JTAG/Serial interface detected, disabling watchdogs")
+		if err := disableWatchdogsESP32S3(f); err != nil {
+			return err
+		}
+	case esp32s3UARTDevBufNoUSBOTG:
+		f.usesUSB = true
+		f.logf("USB-OTG interface detected")
+	}
+
+	return nil
+}
+
+// disableWatchdogsESP32S3 disables the RTC WDT and enables SWD auto-feed.
+// This prevents the watchdog from resetting the chip during flash operations
+// when connected via USB-JTAG/Serial.
+func disableWatchdogsESP32S3(f *Flasher) error {
+	// Unlock and disable RTC WDT
+	if err := f.conn.writeReg(esp32s3RTCCntlWDTWProtect, esp32s3RTCCntlWDTWKey, 0xFFFFFFFF, 0); err != nil {
+		return fmt.Errorf("unlock RTC WDT: %w", err)
+	}
+	if err := f.conn.writeReg(esp32s3RTCCntlWDTConfig0, 0, 0xFFFFFFFF, 0); err != nil {
+		return fmt.Errorf("disable RTC WDT: %w", err)
+	}
+	if err := f.conn.writeReg(esp32s3RTCCntlWDTWProtect, 0, 0xFFFFFFFF, 0); err != nil {
+		return fmt.Errorf("lock RTC WDT: %w", err)
+	}
+
+	// Unlock SWD and enable auto-feed
+	if err := f.conn.writeReg(esp32s3RTCCntlSWDWProtect, esp32s3RTCCntlSWDWKey, 0xFFFFFFFF, 0); err != nil {
+		return fmt.Errorf("unlock SWD: %w", err)
+	}
+
+	swdConf, err := f.conn.readReg(esp32s3RTCCntlSWDConf)
+	if err != nil {
+		return fmt.Errorf("read SWD conf: %w", err)
+	}
+	swdConf |= esp32s3RTCCntlSWDAutoFeedEn
+	if err := f.conn.writeReg(esp32s3RTCCntlSWDConf, swdConf, 0xFFFFFFFF, 0); err != nil {
+		return fmt.Errorf("enable SWD auto-feed: %w", err)
+	}
+	if err := f.conn.writeReg(esp32s3RTCCntlSWDWProtect, 0, 0xFFFFFFFF, 0); err != nil {
+		return fmt.Errorf("lock SWD: %w", err)
+	}
+
+	return nil
 }

--- a/pkg/espflasher/target_esp32s3_test.go
+++ b/pkg/espflasher/target_esp32s3_test.go
@@ -1,0 +1,77 @@
+package espflasher
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestESP32S3PostConnectUSBJTAG(t *testing.T) {
+	var buf bytes.Buffer
+	mc := &mockConnection{
+		readRegFunc: func(addr uint32) (uint32, error) {
+			if addr == esp32s3UARTDevBufNo {
+				return esp32s3UARTDevBufNoUSBJTAGSerial, nil
+			}
+			// Return 0 for SWD conf read
+			return 0, nil
+		},
+		writeRegFunc: func(addr, value, mask, delayUS uint32) error {
+			return nil
+		},
+	}
+	f := &Flasher{
+		conn: mc,
+		opts: &FlasherOptions{Logger: &StdoutLogger{W: &buf}},
+	}
+
+	err := esp32s3PostConnect(f)
+	if err != nil {
+		t.Fatalf("esp32s3PostConnect() error: %v", err)
+	}
+	if !f.usesUSB {
+		t.Error("usesUSB should be true for USB-JTAG/Serial")
+	}
+}
+
+func TestESP32S3PostConnectUSBOTG(t *testing.T) {
+	mc := &mockConnection{
+		readRegFunc: func(addr uint32) (uint32, error) {
+			if addr == esp32s3UARTDevBufNo {
+				return esp32s3UARTDevBufNoUSBOTG, nil
+			}
+			return 0, nil
+		},
+	}
+	f := &Flasher{
+		conn: mc,
+		opts: &FlasherOptions{},
+	}
+
+	err := esp32s3PostConnect(f)
+	if err != nil {
+		t.Fatalf("esp32s3PostConnect() error: %v", err)
+	}
+	if !f.usesUSB {
+		t.Error("usesUSB should be true for USB-OTG")
+	}
+}
+
+func TestESP32S3PostConnectUART(t *testing.T) {
+	mc := &mockConnection{
+		readRegFunc: func(addr uint32) (uint32, error) {
+			return 0, nil // Not USB
+		},
+	}
+	f := &Flasher{
+		conn: mc,
+		opts: &FlasherOptions{},
+	}
+
+	err := esp32s3PostConnect(f)
+	if err != nil {
+		t.Fatalf("esp32s3PostConnect() error: %v", err)
+	}
+	if f.usesUSB {
+		t.Error("usesUSB should be false for UART")
+	}
+}


### PR DESCRIPTION
Adds PostConnect for ESP32-S3 that detects USB-JTAG/Serial vs USB-OTG interface and disables RTC WDT when connected via USB-JTAG/Serial to prevent watchdog resets during flash operations.