### PR TITLE
feat: add ESP32-S2 USB-OTG PostConnect

### DIFF
--- a/pkg/espflasher/target_esp32s2.go
+++ b/pkg/espflasher/target_esp32s2.go
@@ -1,5 +1,12 @@
 package espflasher
 
+// ESP32-S2 register addresses for USB interface detection.
+// Reference: esptool/targets/esp32s2.py
+const (
+	esp32s2UARTDevBufNo       uint32 = 0x3FFFFD14 // ROM .bss: active console interface
+	esp32s2UARTDevBufNoUSBOTG uint32 = 2          // USB-OTG active
+)
+
 // ESP32-S2 target definition.
 // Reference: https://github.com/espressif/esptool/blob/master/esptool/targets/esp32s2.py
 
@@ -41,4 +48,26 @@ var defESP32S2 = &chipDef{
 	},
 
 	FlashSizes: defaultFlashSizes(),
+
+	PostConnect: esp32s2PostConnect,
+}
+
+// esp32s2PostConnect detects the USB interface type.
+// ESP32-S2 only has USB-OTG (no USB-JTAG/Serial), and does not require
+// watchdog disable for USB operation.
+// Reference: esptool/targets/esp32s2.py _post_connect()
+func esp32s2PostConnect(f *Flasher) error {
+	uartDev, err := f.ReadRegister(esp32s2UARTDevBufNo)
+	if err != nil {
+		// In secure download mode, the register may be unreadable.
+		// Default to non-USB behavior (safe fallback).
+		return nil
+	}
+
+	if uartDev == esp32s2UARTDevBufNoUSBOTG {
+		f.usesUSB = true
+		f.logf("USB-OTG interface detected")
+	}
+
+	return nil
 }

--- a/pkg/espflasher/target_esp32s2_test.go
+++ b/pkg/espflasher/target_esp32s2_test.go
@@ -1,0 +1,61 @@
+package espflasher
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestESP32S2PostConnectUSBOTG(t *testing.T) {
+	mc := &mockConnection{
+		readRegFunc: func(addr uint32) (uint32, error) {
+			if addr == esp32s2UARTDevBufNo {
+				return esp32s2UARTDevBufNoUSBOTG, nil
+			}
+			return 0, nil
+		},
+	}
+	f := &Flasher{
+		conn: mc,
+		opts: &FlasherOptions{},
+	}
+
+	err := esp32s2PostConnect(f)
+	require.NoError(t, err)
+	assert.True(t, f.usesUSB, "usesUSB should be true for USB-OTG")
+}
+
+func TestESP32S2PostConnectUART(t *testing.T) {
+	mc := &mockConnection{
+		readRegFunc: func(addr uint32) (uint32, error) {
+			return 0, nil // Not USB, return UART value
+		},
+	}
+	f := &Flasher{
+		conn: mc,
+		opts: &FlasherOptions{},
+	}
+
+	err := esp32s2PostConnect(f)
+	require.NoError(t, err)
+	assert.False(t, f.usesUSB, "usesUSB should be false for UART")
+}
+
+func TestESP32S2PostConnectSecureMode(t *testing.T) {
+	// Simulate read error (secure download mode)
+	mc := &mockConnection{
+		readRegFunc: func(addr uint32) (uint32, error) {
+			return 0, errors.New("register not readable") // Simulate unreadable register
+		},
+	}
+	f := &Flasher{
+		conn: mc,
+		opts: &FlasherOptions{},
+	}
+
+	err := esp32s2PostConnect(f)
+	require.NoError(t, err, "should gracefully handle read error")
+	assert.False(t, f.usesUSB, "should default to non-USB on read error")
+}


### PR DESCRIPTION
Adds PostConnect for ESP32-S2 that detects the USB-OTG interface. ESP32-S2 does not have USB-JTAG/Serial and does not require watchdog disable for USB operation.