### PR TITLE
feat: add ESP32-C3 USB-JTAG PostConnect with RTC_CNTL disable

### DIFF
--- a/pkg/espflasher/target_esp32c3.go
+++ b/pkg/espflasher/target_esp32c3.go
@@ -1,5 +1,34 @@
 package espflasher
 
+import "fmt"
+
+// ESP32-C3 register addresses for USB interface detection and watchdog control.
+// Reference: esptool/targets/esp32c3.py
+const (
+	// UARTDEV_BUF_NO address depends on chip revision (read from efuse).
+	// Revision < 1 (ECO0-ECO3): base 0x3FCDF064
+	// Revision >= 1 (ECO4+): base 0x3FCDF060
+	// The actual register is 24 bytes (+0x18) from the base address.
+	esp32c3UARTDevBufNoRev0         uint32 = 0x3FCDF07C // 0x3FCDF064 + 24
+	esp32c3UARTDevBufNoRev101       uint32 = 0x3FCDF078 // 0x3FCDF060 + 24
+	esp32c3UARTDevBufNoUSBJTAGSerial uint32 = 3          // USB-JTAG/Serial active
+
+	// Efuse register for chip version detection.
+	// Major chip version is in bits 24:22; minor in bits 21:20.
+	esp32c3EfuseRdMacSpiSys1 uint32 = 0x60008844
+
+	// RTC_CNTL watchdog registers (different offsets from S3).
+	esp32c3RTCCntlWDTConfig0  uint32 = 0x60008090
+	esp32c3RTCCntlWDTWProtect uint32 = 0x600080A8
+	esp32c3RTCCntlWDTWKey     uint32 = 0x50D83AA1
+
+	// Super Watchdog (SWD) registers.
+	esp32c3RTCCntlSWDConf       uint32 = 0x600080AC
+	esp32c3RTCCntlSWDAutoFeedEn uint32 = 1 << 31
+	esp32c3RTCCntlSWDWProtect   uint32 = 0x600080B0
+	esp32c3RTCCntlSWDWKey       uint32 = 0x8F1D312A
+)
+
 // ESP32-C3 target definition.
 // Reference: https://github.com/espressif/esptool/blob/master/esptool/targets/esp32c3.py
 
@@ -39,4 +68,93 @@ var defESP32C3 = &chipDef{
 	},
 
 	FlashSizes: defaultFlashSizes(),
+
+	PostConnect: esp32c3PostConnect,
+}
+
+// esp32c3ChipRevision reads the chip revision from efuse.
+// Returns major*100 + minor (e.g., 101 = major 1, minor 0, sub 1).
+// Chip revision is encoded in EFUSE_RD_MAC_SPI_SYS_1_REG:
+//   - Major version: bits 24:22
+//   - Minor version: bits 21:20
+func esp32c3ChipRevision(f *Flasher) (uint32, error) {
+	val, err := f.ReadRegister(esp32c3EfuseRdMacSpiSys1)
+	if err != nil {
+		return 0, err
+	}
+	major := (val >> 22) & 0x7
+	minor := (val >> 20) & 0x3
+	return major*100 + minor, nil
+}
+
+// esp32c3UARTDevAddr returns the correct UARTDEV_BUF_NO address based on chip revision.
+func esp32c3UARTDevAddr(f *Flasher) uint32 {
+	rev, err := esp32c3ChipRevision(f)
+	if err != nil {
+		// Default to older revision if efuse read fails
+		return esp32c3UARTDevBufNoRev0
+	}
+	if rev >= 101 {
+		return esp32c3UARTDevBufNoRev101
+	}
+	return esp32c3UARTDevBufNoRev0
+}
+
+// esp32c3PostConnect detects the USB interface type and disables watchdogs
+// when connected via USB-JTAG/Serial. Without this, the RTC WDT fires
+// during flash and resets the chip mid-operation.
+// Reference: esptool/targets/esp32c3.py _post_connect()
+func esp32c3PostConnect(f *Flasher) error {
+	addr := esp32c3UARTDevAddr(f)
+	val, err := f.ReadRegister(addr)
+	if err != nil {
+		// In secure download mode, the register may be unreadable.
+		// Default to non-USB behavior (safe fallback).
+		return nil
+	}
+
+	if val == esp32c3UARTDevBufNoUSBJTAGSerial {
+		f.usesUSB = true
+		f.logf("USB-JTAG/Serial interface detected, disabling watchdogs")
+		if err := disableWatchdogsESP32C3(f); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// disableWatchdogsESP32C3 disables the RTC WDT and enables SWD auto-feed.
+// This prevents the watchdog from resetting the chip during flash operations
+// when connected via USB-JTAG/Serial.
+func disableWatchdogsESP32C3(f *Flasher) error {
+	// Unlock and disable RTC WDT
+	if err := f.WriteRegister(esp32c3RTCCntlWDTWProtect, esp32c3RTCCntlWDTWKey); err != nil {
+		return fmt.Errorf("unlock RTC WDT: %w", err)
+	}
+	if err := f.WriteRegister(esp32c3RTCCntlWDTConfig0, 0); err != nil {
+		return fmt.Errorf("disable RTC WDT: %w", err)
+	}
+	if err := f.WriteRegister(esp32c3RTCCntlWDTWProtect, 0); err != nil {
+		return fmt.Errorf("lock RTC WDT: %w", err)
+	}
+
+	// Unlock SWD and enable auto-feed
+	if err := f.WriteRegister(esp32c3RTCCntlSWDWProtect, esp32c3RTCCntlSWDWKey); err != nil {
+		return fmt.Errorf("unlock SWD: %w", err)
+	}
+
+	swdConf, err := f.ReadRegister(esp32c3RTCCntlSWDConf)
+	if err != nil {
+		return fmt.Errorf("read SWD conf: %w", err)
+	}
+	swdConf |= esp32c3RTCCntlSWDAutoFeedEn
+	if err := f.WriteRegister(esp32c3RTCCntlSWDConf, swdConf); err != nil {
+		return fmt.Errorf("enable SWD auto-feed: %w", err)
+	}
+	if err := f.WriteRegister(esp32c3RTCCntlSWDWProtect, 0); err != nil {
+		return fmt.Errorf("lock SWD: %w", err)
+	}
+
+	return nil
 }

--- a/pkg/espflasher/target_esp32c3_test.go
+++ b/pkg/espflasher/target_esp32c3_test.go
@@ -1,0 +1,208 @@
+package espflasher
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestESP32C3ChipRevisionRev0(t *testing.T) {
+	// Efuse value with major=0, minor=0
+	mc := &mockConnection{
+		readRegFunc: func(addr uint32) (uint32, error) {
+			if addr == esp32c3EfuseRdMacSpiSys1 {
+				return 0x00000000, nil
+			}
+			return 0, nil
+		},
+	}
+	f := &Flasher{
+		conn: mc,
+		opts: &FlasherOptions{},
+	}
+
+	rev, err := esp32c3ChipRevision(f)
+	require.NoError(t, err)
+	assert.Equal(t, uint32(0), rev, "revision should be 0 for major=0, minor=0")
+}
+
+func TestESP32C3ChipRevisionRev101(t *testing.T) {
+	// Efuse value with major=1, minor=1
+	// major=1: bits 24:22 = (1 << 22) = 0x00400000
+	// minor=1: bits 21:20 = (1 << 20) = 0x00100000
+	// Combined: 0x00500000
+	mc := &mockConnection{
+		readRegFunc: func(addr uint32) (uint32, error) {
+			if addr == esp32c3EfuseRdMacSpiSys1 {
+				// major=1: (1 << 22) = 0x00400000
+				// minor=1: (1 << 20) = 0x00100000
+				// combined: 0x00500000
+				return 0x00500000, nil
+			}
+			return 0, nil
+		},
+	}
+	f := &Flasher{
+		conn: mc,
+		opts: &FlasherOptions{},
+	}
+
+	rev, err := esp32c3ChipRevision(f)
+	require.NoError(t, err)
+	assert.Equal(t, uint32(101), rev, "revision should be 101 for major=1, minor=1")
+}
+
+func TestESP32C3UARTDevAddrRev0(t *testing.T) {
+	// Return major=0, minor=0 from efuse
+	mc := &mockConnection{
+		readRegFunc: func(addr uint32) (uint32, error) {
+			return 0x00000000, nil
+		},
+	}
+	f := &Flasher{
+		conn: mc,
+		opts: &FlasherOptions{},
+	}
+
+	addr := esp32c3UARTDevAddr(f)
+	assert.Equal(t, esp32c3UARTDevBufNoRev0, addr, "should use Rev0 address")
+}
+
+func TestESP32C3UARTDevAddrRev101(t *testing.T) {
+	// Return major=1, minor=1 from efuse (revision 101)
+	mc := &mockConnection{
+		readRegFunc: func(addr uint32) (uint32, error) {
+			if addr == esp32c3EfuseRdMacSpiSys1 {
+				// major=1: (1 << 22) = 0x00400000
+				// minor=1: (1 << 20) = 0x00100000
+				// combined: 0x00500000
+				return 0x00500000, nil
+			}
+			return 0, nil
+		},
+	}
+	f := &Flasher{
+		conn: mc,
+		opts: &FlasherOptions{},
+	}
+
+	addr := esp32c3UARTDevAddr(f)
+	assert.Equal(t, esp32c3UARTDevBufNoRev101, addr, "should use Rev101 address")
+}
+
+func TestESP32C3UARTDevAddrReadError(t *testing.T) {
+	// Efuse read fails, should default to Rev0
+	mc := &mockConnection{
+		readRegFunc: func(addr uint32) (uint32, error) {
+			return 0, errors.New("efuse read error")
+		},
+	}
+	f := &Flasher{
+		conn: mc,
+		opts: &FlasherOptions{},
+	}
+
+	addr := esp32c3UARTDevAddr(f)
+	assert.Equal(t, esp32c3UARTDevBufNoRev0, addr, "should default to Rev0 on read error")
+}
+
+func TestESP32C3PostConnectUSBJTAGRev0(t *testing.T) {
+	writeCount := 0
+	readCount := 0
+
+	mc := &mockConnection{
+		readRegFunc: func(addr uint32) (uint32, error) {
+			readCount++
+			if addr == esp32c3EfuseRdMacSpiSys1 {
+				return 0x00000000, nil // Major=0, Minor=0 -> Rev0
+			}
+			if addr == esp32c3UARTDevBufNoRev0 {
+				return esp32c3UARTDevBufNoUSBJTAGSerial, nil
+			}
+			// Return 0 for SWD conf read
+			return 0, nil
+		},
+		writeRegFunc: func(addr, value, mask, delayUS uint32) error {
+			writeCount++
+			return nil
+		},
+	}
+	f := &Flasher{
+		conn: mc,
+		opts: &FlasherOptions{},
+	}
+
+	err := esp32c3PostConnect(f)
+	require.NoError(t, err)
+	assert.True(t, f.usesUSB, "usesUSB should be true for USB-JTAG/Serial")
+	assert.Greater(t, writeCount, 0, "should have written registers to disable watchdog")
+}
+
+func TestESP32C3PostConnectUSBJTAGRev101(t *testing.T) {
+	writeCount := 0
+
+	mc := &mockConnection{
+		readRegFunc: func(addr uint32) (uint32, error) {
+			if addr == esp32c3EfuseRdMacSpiSys1 {
+				// major=1, minor=1: (1 << 22) | (1 << 20) = 0x00500000
+				return 0x00500000, nil // Major=1, Minor=1 -> Rev101
+			}
+			if addr == esp32c3UARTDevBufNoRev101 {
+				return esp32c3UARTDevBufNoUSBJTAGSerial, nil
+			}
+			// Return 0 for SWD conf read
+			return 0, nil
+		},
+		writeRegFunc: func(addr, value, mask, delayUS uint32) error {
+			writeCount++
+			return nil
+		},
+	}
+	f := &Flasher{
+		conn: mc,
+		opts: &FlasherOptions{},
+	}
+
+	err := esp32c3PostConnect(f)
+	require.NoError(t, err)
+	assert.True(t, f.usesUSB, "usesUSB should be true for USB-JTAG/Serial")
+	assert.Greater(t, writeCount, 0, "should have written registers to disable watchdog")
+}
+
+func TestESP32C3PostConnectUART(t *testing.T) {
+	mc := &mockConnection{
+		readRegFunc: func(addr uint32) (uint32, error) {
+			if addr == esp32c3EfuseRdMacSpiSys1 {
+				return 0x00000000, nil
+			}
+			return 0, nil // Not USB, return UART value
+		},
+	}
+	f := &Flasher{
+		conn: mc,
+		opts: &FlasherOptions{},
+	}
+
+	err := esp32c3PostConnect(f)
+	require.NoError(t, err)
+	assert.False(t, f.usesUSB, "usesUSB should be false for UART")
+}
+
+func TestESP32C3PostConnectSecureMode(t *testing.T) {
+	// Simulate read error (secure download mode)
+	mc := &mockConnection{
+		readRegFunc: func(addr uint32) (uint32, error) {
+			return 0, errors.New("register not readable") // Simulate unreadable register
+		},
+	}
+	f := &Flasher{
+		conn: mc,
+		opts: &FlasherOptions{},
+	}
+
+	err := esp32c3PostConnect(f)
+	require.NoError(t, err, "should gracefully handle read error")
+	assert.False(t, f.usesUSB, "should default to non-USB on read error")
+}


### PR DESCRIPTION
Adds PostConnect for ESP32-C3 that detects USB-JTAG/Serial and disables the RTC_CNTL watchdog. Includes chip revision detection for the correct UARTDEV_BUF_NO address.