### PR TITLE
feat: add LP_WDT PostConnect for ESP32-C6, H2, and C5

### DIFF
--- a/pkg/espflasher/target_esp32c5.go
+++ b/pkg/espflasher/target_esp32c5.go
@@ -1,5 +1,17 @@
 package espflasher
 
+// ESP32-C5 register addresses for USB interface detection and watchdog control.
+// Reference: esptool/targets/esp32c5.py
+const (
+	esp32c5UARTDevBufNo              uint32 = 0x4085F514 // ROM .bss: active console interface
+	esp32c5UARTDevBufNoUSBJTAGSerial uint32 = 3          // USB-JTAG/Serial active
+
+	esp32c5LPWDTConfig0     uint32 = 0x600B1C00
+	esp32c5LPWDTWProtect    uint32 = 0x600B1C18
+	esp32c5LPWDTSWDConf     uint32 = 0x600B1C1C
+	esp32c5LPWDTSWDWProtect uint32 = 0x600B1C20
+)
+
 // ESP32-C5 target definition.
 // Reference: https://github.com/espressif/esptool/blob/master/esptool/targets/esp32c5.py
 
@@ -39,4 +51,27 @@ var defESP32C5 = &chipDef{
 	},
 
 	FlashSizes: defaultFlashSizes(),
+
+	PostConnect: esp32c5PostConnect,
+}
+
+// esp32c5PostConnect detects the USB interface type and disables watchdogs
+// when connected via USB-JTAG/Serial. Without this, the LP WDT fires
+// during flash and resets the chip mid-operation.
+// Reference: esptool/targets/esp32c5.py _post_connect()
+func esp32c5PostConnect(f *Flasher) error {
+	uartDev, err := f.ReadRegister(esp32c5UARTDevBufNo)
+	if err != nil {
+		// In secure download mode, the register may be unreadable.
+		// Default to non-USB behavior (safe fallback).
+		return nil
+	}
+
+	if uartDev == esp32c5UARTDevBufNoUSBJTAGSerial {
+		f.usesUSB = true
+		f.logf("USB-JTAG/Serial interface detected, disabling watchdogs")
+		return disableWatchdogsLP(f, esp32c5LPWDTConfig0, esp32c5LPWDTWProtect, esp32c5LPWDTSWDConf, esp32c5LPWDTSWDWProtect)
+	}
+
+	return nil
 }

--- a/pkg/espflasher/target_esp32c5_test.go
+++ b/pkg/espflasher/target_esp32c5_test.go
@@ -1,0 +1,71 @@
+package espflasher
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestESP32C5PostConnectUSBJTAG(t *testing.T) {
+	writeCount := 0
+	readCount := 0
+
+	mc := &mockConnection{
+		readRegFunc: func(addr uint32) (uint32, error) {
+			readCount++
+			if addr == esp32c5UARTDevBufNo {
+				return esp32c5UARTDevBufNoUSBJTAGSerial, nil
+			}
+			// Return 0 for SWD conf read
+			return 0, nil
+		},
+		writeRegFunc: func(addr, value, mask, delayUS uint32) error {
+			writeCount++
+			return nil
+		},
+	}
+	f := &Flasher{
+		conn: mc,
+		opts: &FlasherOptions{},
+	}
+
+	err := esp32c5PostConnect(f)
+	require.NoError(t, err)
+	assert.True(t, f.usesUSB, "usesUSB should be true for USB-JTAG/Serial")
+	assert.Greater(t, writeCount, 0, "should have written registers to disable watchdog")
+}
+
+func TestESP32C5PostConnectUART(t *testing.T) {
+	mc := &mockConnection{
+		readRegFunc: func(addr uint32) (uint32, error) {
+			return 0, nil // Not USB, return UART value
+		},
+	}
+	f := &Flasher{
+		conn: mc,
+		opts: &FlasherOptions{},
+	}
+
+	err := esp32c5PostConnect(f)
+	require.NoError(t, err)
+	assert.False(t, f.usesUSB, "usesUSB should be false for UART")
+}
+
+func TestESP32C5PostConnectSecureMode(t *testing.T) {
+	// Simulate read error (secure download mode)
+	mc := &mockConnection{
+		readRegFunc: func(addr uint32) (uint32, error) {
+			return 0, errors.New("register not readable") // Simulate unreadable register
+		},
+	}
+	f := &Flasher{
+		conn: mc,
+		opts: &FlasherOptions{},
+	}
+
+	err := esp32c5PostConnect(f)
+	require.NoError(t, err, "should gracefully handle read error")
+	assert.False(t, f.usesUSB, "should default to non-USB on read error")
+}

--- a/pkg/espflasher/target_esp32c6.go
+++ b/pkg/espflasher/target_esp32c6.go
@@ -1,5 +1,17 @@
 package espflasher
 
+// ESP32-C6 register addresses for USB interface detection and watchdog control.
+// Reference: esptool/targets/esp32c6.py
+const (
+	esp32c6UARTDevBufNo              uint32 = 0x4087F580 // ROM .bss: active console interface
+	esp32c6UARTDevBufNoUSBJTAGSerial uint32 = 3          // USB-JTAG/Serial active
+
+	esp32c6LPWDTConfig0     uint32 = 0x600B1C00
+	esp32c6LPWDTWProtect    uint32 = 0x600B1C18
+	esp32c6LPWDTSWDConf     uint32 = 0x600B1C1C
+	esp32c6LPWDTSWDWProtect uint32 = 0x600B1C20
+)
+
 // ESP32-C6 target definition.
 // Reference: https://github.com/espressif/esptool/blob/master/esptool/targets/esp32c6.py
 
@@ -39,4 +51,27 @@ var defESP32C6 = &chipDef{
 	},
 
 	FlashSizes: defaultFlashSizes(),
+
+	PostConnect: esp32c6PostConnect,
+}
+
+// esp32c6PostConnect detects the USB interface type and disables watchdogs
+// when connected via USB-JTAG/Serial. Without this, the LP WDT fires
+// during flash and resets the chip mid-operation.
+// Reference: esptool/targets/esp32c6.py _post_connect()
+func esp32c6PostConnect(f *Flasher) error {
+	uartDev, err := f.ReadRegister(esp32c6UARTDevBufNo)
+	if err != nil {
+		// In secure download mode, the register may be unreadable.
+		// Default to non-USB behavior (safe fallback).
+		return nil
+	}
+
+	if uartDev == esp32c6UARTDevBufNoUSBJTAGSerial {
+		f.usesUSB = true
+		f.logf("USB-JTAG/Serial interface detected, disabling watchdogs")
+		return disableWatchdogsLP(f, esp32c6LPWDTConfig0, esp32c6LPWDTWProtect, esp32c6LPWDTSWDConf, esp32c6LPWDTSWDWProtect)
+	}
+
+	return nil
 }

--- a/pkg/espflasher/target_esp32c6_test.go
+++ b/pkg/espflasher/target_esp32c6_test.go
@@ -1,0 +1,71 @@
+package espflasher
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestESP32C6PostConnectUSBJTAG(t *testing.T) {
+	writeCount := 0
+	readCount := 0
+
+	mc := &mockConnection{
+		readRegFunc: func(addr uint32) (uint32, error) {
+			readCount++
+			if addr == esp32c6UARTDevBufNo {
+				return esp32c6UARTDevBufNoUSBJTAGSerial, nil
+			}
+			// Return 0 for SWD conf read
+			return 0, nil
+		},
+		writeRegFunc: func(addr, value, mask, delayUS uint32) error {
+			writeCount++
+			return nil
+		},
+	}
+	f := &Flasher{
+		conn: mc,
+		opts: &FlasherOptions{},
+	}
+
+	err := esp32c6PostConnect(f)
+	require.NoError(t, err)
+	assert.True(t, f.usesUSB, "usesUSB should be true for USB-JTAG/Serial")
+	assert.Greater(t, writeCount, 0, "should have written registers to disable watchdog")
+}
+
+func TestESP32C6PostConnectUART(t *testing.T) {
+	mc := &mockConnection{
+		readRegFunc: func(addr uint32) (uint32, error) {
+			return 0, nil // Not USB, return UART value
+		},
+	}
+	f := &Flasher{
+		conn: mc,
+		opts: &FlasherOptions{},
+	}
+
+	err := esp32c6PostConnect(f)
+	require.NoError(t, err)
+	assert.False(t, f.usesUSB, "usesUSB should be false for UART")
+}
+
+func TestESP32C6PostConnectSecureMode(t *testing.T) {
+	// Simulate read error (secure download mode)
+	mc := &mockConnection{
+		readRegFunc: func(addr uint32) (uint32, error) {
+			return 0, errors.New("register not readable") // Simulate unreadable register
+		},
+	}
+	f := &Flasher{
+		conn: mc,
+		opts: &FlasherOptions{},
+	}
+
+	err := esp32c6PostConnect(f)
+	require.NoError(t, err, "should gracefully handle read error")
+	assert.False(t, f.usesUSB, "should default to non-USB on read error")
+}

--- a/pkg/espflasher/target_esp32h2.go
+++ b/pkg/espflasher/target_esp32h2.go
@@ -1,5 +1,17 @@
 package espflasher
 
+// ESP32-H2 register addresses for USB interface detection and watchdog control.
+// Reference: esptool/targets/esp32h2.py
+const (
+	esp32h2UARTDevBufNo              uint32 = 0x4084FEFC // ROM .bss: active console interface
+	esp32h2UARTDevBufNoUSBJTAGSerial uint32 = 3          // USB-JTAG/Serial active
+
+	esp32h2LPWDTConfig0      uint32 = 0x600B1C00
+	esp32h2LPWDTWProtect     uint32 = 0x600B1C1C // H2 offset differs from C6
+	esp32h2LPWDTSWDConf      uint32 = 0x600B1C20
+	esp32h2LPWDTSWDWProtect  uint32 = 0x600B1C24
+)
+
 // ESP32-H2 target definition.
 // Reference: https://github.com/espressif/esptool/blob/master/esptool/targets/esp32h2.py
 
@@ -40,4 +52,27 @@ var defESP32H2 = &chipDef{
 	},
 
 	FlashSizes: defaultFlashSizes(),
+
+	PostConnect: esp32h2PostConnect,
+}
+
+// esp32h2PostConnect detects the USB interface type and disables watchdogs
+// when connected via USB-JTAG/Serial. Without this, the LP WDT fires
+// during flash and resets the chip mid-operation.
+// Reference: esptool/targets/esp32h2.py _post_connect()
+func esp32h2PostConnect(f *Flasher) error {
+	uartDev, err := f.ReadRegister(esp32h2UARTDevBufNo)
+	if err != nil {
+		// In secure download mode, the register may be unreadable.
+		// Default to non-USB behavior (safe fallback).
+		return nil
+	}
+
+	if uartDev == esp32h2UARTDevBufNoUSBJTAGSerial {
+		f.usesUSB = true
+		f.logf("USB-JTAG/Serial interface detected, disabling watchdogs")
+		return disableWatchdogsLP(f, esp32h2LPWDTConfig0, esp32h2LPWDTWProtect, esp32h2LPWDTSWDConf, esp32h2LPWDTSWDWProtect)
+	}
+
+	return nil
 }

--- a/pkg/espflasher/target_esp32h2_test.go
+++ b/pkg/espflasher/target_esp32h2_test.go
@@ -1,0 +1,77 @@
+package espflasher
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestESP32H2PostConnectUSBJTAG(t *testing.T) {
+	writeCount := 0
+	readCount := 0
+	writeAddrs := []uint32{}
+
+	mc := &mockConnection{
+		readRegFunc: func(addr uint32) (uint32, error) {
+			readCount++
+			if addr == esp32h2UARTDevBufNo {
+				return esp32h2UARTDevBufNoUSBJTAGSerial, nil
+			}
+			// Return 0 for SWD conf read
+			return 0, nil
+		},
+		writeRegFunc: func(addr, value, mask, delayUS uint32) error {
+			writeCount++
+			writeAddrs = append(writeAddrs, addr)
+			return nil
+		},
+	}
+	f := &Flasher{
+		conn: mc,
+		opts: &FlasherOptions{},
+	}
+
+	err := esp32h2PostConnect(f)
+	require.NoError(t, err)
+	assert.True(t, f.usesUSB, "usesUSB should be true for USB-JTAG/Serial")
+	assert.Greater(t, writeCount, 0, "should have written registers to disable watchdog")
+
+	// Verify H2-specific register offsets were used
+	assert.Contains(t, writeAddrs, esp32h2LPWDTWProtect, "should write to H2 LP_WDT wprotect")
+	assert.Contains(t, writeAddrs, esp32h2LPWDTSWDWProtect, "should write to H2 LP_WDT SWD wprotect")
+}
+
+func TestESP32H2PostConnectUART(t *testing.T) {
+	mc := &mockConnection{
+		readRegFunc: func(addr uint32) (uint32, error) {
+			return 0, nil // Not USB, return UART value
+		},
+	}
+	f := &Flasher{
+		conn: mc,
+		opts: &FlasherOptions{},
+	}
+
+	err := esp32h2PostConnect(f)
+	require.NoError(t, err)
+	assert.False(t, f.usesUSB, "usesUSB should be false for UART")
+}
+
+func TestESP32H2PostConnectSecureMode(t *testing.T) {
+	// Simulate read error (secure download mode)
+	mc := &mockConnection{
+		readRegFunc: func(addr uint32) (uint32, error) {
+			return 0, errors.New("register not readable") // Simulate unreadable register
+		},
+	}
+	f := &Flasher{
+		conn: mc,
+		opts: &FlasherOptions{},
+	}
+
+	err := esp32h2PostConnect(f)
+	require.NoError(t, err, "should gracefully handle read error")
+	assert.False(t, f.usesUSB, "should default to non-USB on read error")
+}

--- a/pkg/espflasher/watchdog.go
+++ b/pkg/espflasher/watchdog.go
@@ -1,0 +1,35 @@
+package espflasher
+
+// disableWatchdogsLP disables LP domain watchdogs on RISC-V chips (C6, H2, C5).
+// Register addresses vary per chip but the protocol is identical:
+// unlock WDT write-protect, disable WDT, re-lock, then unlock SWD, enable auto-feed, re-lock.
+func disableWatchdogsLP(f *Flasher, wdtConfig0, wdtWProtect, swdConf, swdWProtect uint32) error {
+	const (
+		lpWDTWKey       uint32 = 0x50D83AA1
+		lpSWDAutoFeedEn uint32 = 1 << 18
+	)
+
+	// Unlock and disable RTC/LP WDT
+	if err := f.WriteRegister(wdtWProtect, lpWDTWKey); err != nil {
+		return err
+	}
+	if err := f.WriteRegister(wdtConfig0, 0); err != nil {
+		return err
+	}
+	if err := f.WriteRegister(wdtWProtect, 0); err != nil {
+		return err
+	}
+
+	// Unlock SWD, enable auto-feed, re-lock
+	if err := f.WriteRegister(swdWProtect, lpWDTWKey); err != nil {
+		return err
+	}
+	val, err := f.ReadRegister(swdConf)
+	if err != nil {
+		return err
+	}
+	if err := f.WriteRegister(swdConf, val|lpSWDAutoFeedEn); err != nil {
+		return err
+	}
+	return f.WriteRegister(swdWProtect, 0)
+}


### PR DESCRIPTION
Adds PostConnect for ESP32-C6, ESP32-H2, and ESP32-C5 with shared LP_WDT (Low Power watchdog) disable. These RISC-V chips share the same LP domain watchdog protocol with chip-specific register addresses. Includes a shared disableWatchdogsLP helper in watchdog.go.