### PR TITLE
espflasher: add USB-JTAG/Serial reset support for ESP32-S3/C3/C6/H2

### DIFF
--- a/pkg/espflasher/flasher.go
+++ b/pkg/espflasher/flasher.go
@@ -203,6 +203,40 @@ func (f *Flasher) reopenPort() error {
 	return fmt.Errorf("reopen port %s: %w", f.portStr, lastErr)
 }
 
+// connectViaUSBJTAG performs a USB-JTAG/Serial reset and attempts to
+// reconnect. The reset causes the USB device to disconnect and
+// re-enumerate, so the old port is closed and a new one is opened.
+//
+// The reset sequence is run in a goroutine because ioctls on a
+// disconnected cdc_acm fd can block for several seconds on Linux.
+// After a short timeout we close the old port (which unblocks the
+// goroutine) and wait for the device to re-enumerate.
+func (f *Flasher) connectViaUSBJTAG() bool {
+	done := make(chan struct{})
+	go func() {
+		usbJTAGSerialReset(f.port)
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(500 * time.Millisecond):
+		// Reset likely triggered but post-disconnect ioctls are blocking.
+		// reopenPort will close the fd, unblocking the goroutine.
+	}
+	if err := f.reopenPort(); err != nil {
+		return false
+	}
+	f.conn.flushInput()
+	for range 5 {
+		_, err := f.conn.sync()
+		if err == nil {
+			return true
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	return false
+}
+
 // ChipType returns the detected chip type.
 func (f *Flasher) ChipType() ChipType {
 	if f.chip != nil {
@@ -236,16 +270,22 @@ func (f *Flasher) connect() error {
 			if attempt%2 == 0 {
 				classicReset(f.port, defaultResetDelay)
 			} else {
-				tightReset(f.port, defaultResetDelay+500*time.Millisecond)
+				tightReset(f.port, defaultResetDelay)
 			}
 		case ResetUSBJTAG:
-			usbJTAGSerialReset(f.port)
+			if f.connectViaUSBJTAG() {
+				goto synced
+			}
+			continue
 		case ResetAuto:
 			switch attempt % 3 {
 			case 0:
 				classicReset(f.port, defaultResetDelay)
 			case 1:
-				usbJTAGSerialReset(f.port)
+				if f.connectViaUSBJTAG() {
+					goto synced
+				}
+				continue
 			case 2:
 				// No reset — device may already be in bootloader
 			}
@@ -263,9 +303,24 @@ func (f *Flasher) connect() error {
 			time.Sleep(50 * time.Millisecond)
 		}
 
-		// Sync failed — try reopening port (USB CDC may have re-enumerated)
+		// Sync failed — try reopening port (USB CDC may have re-enumerated
+		// after reset, causing the old port handle to be stale).
 		if err := f.reopenPort(); err != nil {
 			continue // port reopen failed, try next attempt
+		}
+
+		// Port reopened successfully — the device likely just finished
+		// USB re-enumeration after the reset above and the bootloader
+		// is already waiting for commands. Try to sync now before
+		// looping back and issuing another reset (which would disconnect
+		// USB all over again).
+		f.conn.flushInput()
+		for range 5 {
+			_, err := f.conn.sync()
+			if err == nil {
+				goto synced
+			}
+			time.Sleep(50 * time.Millisecond)
 		}
 	}
 
@@ -780,17 +835,33 @@ func (f *Flasher) ReadFlash(offset, size uint32) ([]byte, error) {
 func (f *Flasher) Reset() {
 	if f.conn.isStub() {
 		// The stub loader needs an explicit flash_begin/flash_end to
-		// cleanly exit flash mode before hardware reset.
+		// cleanly exit flash mode before hardware reset. Use reboot=false
+		// to keep the stub running so the port stays alive for hardReset.
 		f.conn.flashBegin(0, 0, false) //nolint:errcheck
-		f.conn.flashEnd(true)          //nolint:errcheck
+		f.conn.flashEnd(false)         //nolint:errcheck
 		time.Sleep(50 * time.Millisecond)
 	}
 
-	// For ROM bootloaders, skip flash_begin/flash_end — sending
-	// CMD_FLASH_BEGIN after a compressed download may interfere with
-	// the flash controller state at offset 0. esptool also just does
-	// a hard reset without any flash commands for the ROM path.
-	hardReset(f.port, f.usesUSB)
+	if f.usesUSB {
+		// On USB-JTAG/Serial, hardReset's SetRTS(true) pulls EN low while
+		// USB is still connected. During the 200ms sleep the chip resets
+		// and USB disconnects. The subsequent SetRTS(false) may block on
+		// the dead cdc_acm fd. Run in a goroutine and close the port
+		// after a timeout so the kernel releases the tty device node.
+		done := make(chan struct{})
+		go func() {
+			hardReset(f.port, true)
+			close(done)
+		}()
+		select {
+		case <-done:
+		case <-time.After(500 * time.Millisecond):
+		}
+		f.port.Close() //nolint:errcheck
+		<-done         // wait for goroutine to finish after fd closed
+	} else {
+		hardReset(f.port, false)
+	}
 	f.logf("Device reset.")
 }
 

--- a/pkg/espflasher/protocol.go
+++ b/pkg/espflasher/protocol.go
@@ -80,8 +80,8 @@ const (
 
 // conn wraps the serial port and provides the low-level protocol operations.
 type conn struct {
-	port   serial.Port
-	reader *slipReader
+	port    serial.Port
+	reader  *slipReader
 	stub    bool
 	usesUSB bool // set for USB-OTG and USB-JTAG/Serial connections
 	// supportsEncryptedFlash indicates the ROM supports the 5th parameter
@@ -137,13 +137,22 @@ func (c *conn) sendCommand(opcode byte, data []byte, chk uint32) error {
 	// USB CDC endpoints have limited buffer sizes. Writing large SLIP frames
 	// in one shot can overflow the endpoint buffer and cause data loss.
 	// Chunk writes to 64 bytes (standard USB Full Speed bulk endpoint size).
-	const maxChunk = 64
-	for off := 0; off < len(frame); off += maxChunk {
-		end := off + maxChunk
-		if end > len(frame) {
-			end = len(frame)
+	// Only use chunking for native USB connections (USB-OTG, USB-JTAG/Serial);
+	// UART bridge connections (CH340, CP2102 etc.) handle large writes fine
+	// and chunking just adds unnecessary syscall overhead.
+	if c.usesUSB {
+		const maxChunk = 64
+		for off := 0; off < len(frame); off += maxChunk {
+			end := off + maxChunk
+			if end > len(frame) {
+				end = len(frame)
+			}
+			if _, err := c.port.Write(frame[off:end]); err != nil {
+				return err
+			}
 		}
-		if _, err := c.port.Write(frame[off:end]); err != nil {
+	} else {
+		if _, err := c.port.Write(frame); err != nil {
 			return err
 		}
 	}
@@ -269,9 +278,14 @@ func (c *conn) sync() (uint32, error) {
 		return 0, err
 	}
 
-	// Read remaining sync responses (ROM sends up to 7 more)
+	// The ROM bootloader sends up to 7 additional sync responses after the
+	// first one. Drain them by reading frames directly (don't send new
+	// commands). Use a short timeout: the responses should already be in the
+	// serial buffer or arrive within a few milliseconds.
 	for range 7 {
-		c.command(0, nil, 0, syncTimeout, true) //nolint:errcheck
+		if _, err := c.reader.ReadFrame(50 * time.Millisecond); err != nil {
+			break // no more responses waiting — stop early
+		}
 	}
 
 	return resp.Value, nil

--- a/pkg/espflasher/protocol_test.go
+++ b/pkg/espflasher/protocol_test.go
@@ -624,7 +624,7 @@ func makeChangeBaudResponse() []byte {
 }
 
 func TestSendCommandChunking(t *testing.T) {
-	// Verify that sendCommand writes in chunks <= 64 bytes
+	// Verify that sendCommand writes in chunks <= 64 bytes for USB connections
 	var writes [][]byte
 	mock := &mockPort{
 		writeFunc: func(data []byte) (int, error) {
@@ -637,8 +637,9 @@ func TestSendCommandChunking(t *testing.T) {
 	}
 
 	c := &conn{
-		port:   mock,
-		reader: &slipReader{port: mock},
+		port:    mock,
+		reader:  &slipReader{port: mock},
+		usesUSB: true, // chunking only applies to USB connections
 	}
 
 	// Create test data that will result in a large SLIP frame

--- a/pkg/espflasher/reset.go
+++ b/pkg/espflasher/reset.go
@@ -2,6 +2,7 @@ package espflasher
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"go.bug.st/serial"
@@ -88,26 +89,39 @@ func tightReset(port serial.Port, delay time.Duration) {
 // usbJTAGSerialReset performs reset for USB-JTAG/Serial interfaces.
 // Used on ESP32-C3, ESP32-S3, ESP32-C6, ESP32-H2 when using the
 // built-in USB-JTAG/Serial peripheral.
+//
+// The sequence matches esptool's USBJTAGSerialReset: assert DTR (IO0=LOW
+// for bootloader), then toggle RTS through (1,1) to trigger reset, then
+// release. After SetRTS(true) the USB device may disconnect; subsequent
+// ioctls may block on Linux's cdc_acm driver, so callers should run this
+// in a goroutine with a timeout.
 func usbJTAGSerialReset(port serial.Port) {
 	port.SetRTS(false) //nolint:errcheck
-	port.SetDTR(false) //nolint:errcheck
+	port.SetDTR(false) //nolint:errcheck // Idle
 	time.Sleep(100 * time.Millisecond)
 
-	port.SetDTR(true)  //nolint:errcheck
+	port.SetDTR(true)  //nolint:errcheck // IO0=LOW (bootloader mode)
 	port.SetRTS(false) //nolint:errcheck
 	time.Sleep(100 * time.Millisecond)
 
-	port.SetRTS(true)  //nolint:errcheck
+	// Trigger reset. Go through (1,1) instead of (0,0).
+	// USB device may disconnect here.
+	port.SetRTS(true)  //nolint:errcheck // EN=LOW (reset)
 	port.SetDTR(false) //nolint:errcheck
-	port.SetRTS(true)  //nolint:errcheck
+	port.SetRTS(true)  //nolint:errcheck // Propagate DTR on RTS (Windows)
 	time.Sleep(100 * time.Millisecond)
-
-	port.SetRTS(false) //nolint:errcheck
 	port.SetDTR(false) //nolint:errcheck
+	port.SetRTS(false) //nolint:errcheck // EN=HIGH (chip out of reset)
 }
 
 // hardReset performs a hardware reset (chip restarts and runs user code).
 func hardReset(port serial.Port, usesUSB bool) {
+	if usesUSB {
+		// On USB-JTAG/Serial, the peripheral latches DTR (GPIO0 state)
+		// at reset time. Ensure DTR=false so GPIO0=HIGH → normal boot,
+		// not bootloader mode.
+		port.SetDTR(false) //nolint:errcheck
+	}
 	port.SetRTS(true) //nolint:errcheck
 	if usesUSB {
 		time.Sleep(200 * time.Millisecond)
@@ -117,6 +131,17 @@ func hardReset(port serial.Port, usesUSB bool) {
 		time.Sleep(100 * time.Millisecond)
 		port.SetRTS(false) //nolint:errcheck
 	}
+}
+
+// isNativeUSBPort returns true if the port path looks like a CDC ACM device
+// (native USB) rather than a USB-UART bridge. On native USB connections,
+// DTR/RTS ioctls after a chip reset will block because the USB device
+// disconnects, so a different reset strategy is needed.
+func isNativeUSBPort(portName string) bool {
+	// Linux: /dev/ttyACM*  (cdc_acm driver)
+	// macOS: /dev/cu.usbmodem*  (AppleUSBCDC driver)
+	return strings.Contains(portName, "ttyACM") ||
+		strings.Contains(portName, "usbmodem")
 }
 
 // String returns the string representation of the ResetMode.


### PR DESCRIPTION
Add proper handling for chips connected via the built-in USB-JTAG/Serial peripheral (ttyACM/usbmodem ports), where DTR/RTS ioctls on a disconnected cdc_acm fd block for ~5s each on Linux.

Key changes:

- Add connectViaUSBJTAG() which runs usbJTAGSerialReset in a goroutine with a 500ms timeout, then closes the stale port and reopens after USB re-enumeration. Used by ResetUSBJTAG and ResetAuto modes.

- Fix usbJTAGSerialReset to match esptool's full USBJTAGSerialReset sequence: idle → set IO0 → trigger reset through (1,1) → release EN.

- Fix hardReset to deassert DTR before toggling RTS on USB connections, so GPIO0=HIGH at reset and the chip boots into user code instead of bootloader mode.

- Fix Reset() to use flashEnd(reboot=false) to keep the stub running and USB alive for the subsequent hardReset, and run hardReset in a goroutine to avoid blocking on the dead fd after the chip resets.

- Make 64-byte USB CDC write chunking conditional on usesUSB flag to avoid unnecessary syscall overhead on UART bridge connections.

- Optimize sync() to drain extra ROM responses via direct frame reads instead of sending dummy commands.

- After failed sync, try reopening the port and syncing again before looping back to issue another reset.