### PR TITLE
Fix outdated comments and add missing ESP32-C5 support in CLI

### DIFF
--- a/main.go
+++ b/main.go
@@ -26,13 +26,13 @@ func main() {
 	port := flag.String("port", "", "Serial port (e.g. /dev/ttyUSB0, COM3)")
 	baud := flag.Int("baud", 460800, "Flash baud rate")
 	offset := flag.String("offset", "0x0", "Flash offset for single binary mode")
-	chip := flag.String("chip", "auto", "Chip type: auto, esp8266, esp32, esp32s2, esp32s3, esp32c2, esp32c3, esp32c6, esp32h2")
+	chip := flag.String("chip", "auto", "Chip type: auto, esp8266, esp32, esp32s2, esp32s3, esp32c2, esp32c3, esp32c5, esp32c6, esp32h2")
 	noCompress := flag.Bool("no-compress", false, "Disable compression")
 	eraseAll := flag.Bool("erase-all", false, "Erase entire flash before writing")
 	flashMode := flag.String("fm", "keep", "Flash mode: keep, qio, qout, dio, dout")
 	flashFreq := flag.String("ff", "keep", "Flash frequency: keep, 80m, 40m, 26m, 20m (chip-specific)")
 	flashSize := flag.String("fs", "keep", "Flash size: keep, 1MB, 2MB, 4MB, 8MB, 16MB")
-	resetMode := flag.String("reset", "default", "Reset mode: default, no-reset, usb-jtag")
+	resetMode := flag.String("reset", "default", "Reset mode: default, no-reset, usb-jtag, auto")
 	version := flag.Bool("version", false, "Print version and exit")
 
 	// Multi-image mode
@@ -104,6 +104,8 @@ func main() {
 		opts.ResetMode = espflasher.ResetNoReset
 	case "usb-jtag":
 		opts.ResetMode = espflasher.ResetUSBJTAG
+	case "auto":
+		opts.ResetMode = espflasher.ResetAuto
 	default:
 		log.Fatalf("Unknown reset mode: %s", *resetMode)
 	}
@@ -224,6 +226,8 @@ func parseChipType(s string) espflasher.ChipType {
 		return espflasher.ChipESP32C2
 	case "esp32c3", "esp32-c3":
 		return espflasher.ChipESP32C3
+	case "esp32c5", "esp32-c5":
+		return espflasher.ChipESP32C5
 	case "esp32c6", "esp32-c6":
 		return espflasher.ChipESP32C6
 	case "esp32h2", "esp32-h2":

--- a/pkg/espflasher/chip.go
+++ b/pkg/espflasher/chip.go
@@ -56,11 +56,11 @@ type chipDef struct {
 	Name string
 
 	// MagicValue is read from CHIP_DETECT_MAGIC_REG_ADDR on older chips.
-	// Only used for ESP8266 and ESP32 which don't support get_chip_id.
+	// Only used for ESP8266, ESP32, and ESP32-S2 which don't support get_chip_id.
 	MagicValue uint32
 
 	// ImageChipID is returned by the GET_SECURITY_INFO command on newer chips.
-	// ESP8266 and ESP32 use magic value detection instead (ImageChipID = 0).
+	// ESP8266, ESP32, and ESP32-S2 use magic value detection instead.
 	ImageChipID uint32
 
 	// UsesMagicValue indicates this chip uses the magic register for detection

--- a/pkg/espflasher/doc.go
+++ b/pkg/espflasher/doc.go
@@ -9,6 +9,7 @@
 //   - ESP32-S3
 //   - ESP32-C2 (ESP8684)
 //   - ESP32-C3
+//   - ESP32-C5
 //   - ESP32-C6
 //   - ESP32-H2
 //
@@ -16,7 +17,7 @@
 //
 // To flash a .bin file to a connected ESP device:
 //
-//	flasher, err := espflasher.NewFlasher("/dev/ttyUSB0", nil)
+//	flasher, err := espflasher.New("/dev/ttyUSB0", nil)
 //	if err != nil {
 //	    log.Fatal(err)
 //	}
@@ -36,6 +37,8 @@
 //   - SLIP: Serial Line Internet Protocol framing (slip.go)
 //   - Protocol: ROM bootloader command/response protocol (protocol.go)
 //   - Chip: Per-target chip definitions and detection (chip.go, target_*.go)
+//   - Image: Firmware image header parsing and patching (image.go)
+//   - Stub: Stub loader for advanced operations like erase and read (stub.go)
 //   - Flasher: High-level flash/verify/reset API (flasher.go)
 //
 // The protocol uses SLIP framing over serial UART. Commands are sent as

--- a/pkg/espflasher/reset.go
+++ b/pkg/espflasher/reset.go
@@ -86,7 +86,7 @@ func tightReset(port serial.Port, delay time.Duration) {
 }
 
 // usbJTAGSerialReset performs reset for USB-JTAG/Serial interfaces.
-// Used on ESP32-C3, ESP32-S3, ESP32-C6, ESP32-H2 when using the
+// Used on ESP32-C3, ESP32-S3, ESP32-C5, ESP32-C6, ESP32-H2 when using the
 // built-in USB-JTAG/Serial peripheral.
 //
 // The sequence matches esptool's USBJTAGSerialReset: assert DTR (IO0=LOW


### PR DESCRIPTION
- Update chip.go comments to include ESP32-S2 in magic value detection
- Add ESP32-C5 to USB-JTAG/Serial reset comment in reset.go
- Add missing esp32c5 to -chip flag and parseChipType() in main.go
- Add missing auto to -reset flag and reset mode switch in main.go