### PR TITLE
fix(flasher): pass detected flash size to SPI_SET_PARAMS (#41)

### DIFF
--- a/pkg/espflasher/flasher.go
+++ b/pkg/espflasher/flasher.go
@@ -541,12 +541,20 @@ func (f *Flasher) FlashImages(images []ImagePart, progress ProgressFunc) error {
 		return fmt.Errorf("attach flash: %w", err)
 	}
 
-	// Auto-detect flash size when not explicitly set.
+	// Auto-detect flash size when not explicitly set, then re-push the SPI
+	// params so the stub knows the real chip size. Without the re-push, the
+	// stub keeps its default 4 MB bound from the initial attachFlash() and
+	// rejects any write past 4 MB with ESP_FAILED_SPI_OP (status 0xC4).
 	if f.opts.FlashSize == "" || f.opts.FlashSize == "keep" {
 		if detected := f.detectFlashSize(); detected != "" {
 			f.logf("Configuring flash size...")
 			f.logf("Auto-detected flash size: %s", detected)
 			f.opts.FlashSize = detected
+		}
+	}
+	if f.chip == nil || f.chip.ChipType != ChipESP8266 {
+		if err := f.configureSPIForSize(); err != nil {
+			return err
 		}
 	}
 
@@ -903,20 +911,55 @@ func (f *Flasher) attachFlash() error {
 		return err
 	}
 
-	// Configure flash parameters for common 4MB flash
-	// These defaults work for most development boards
+	return f.configureSPIForSize()
+}
+
+// configureSPIForSize tells the stub the flash chip's actual size derived
+// from f.opts.FlashSize. Without this, the stub keeps the default 4 MB
+// bound and rejects any write past 4 MB with ESP_FAILED_SPI_OP (status
+// 0xC4). Falls back to 4 MB when the size string is empty / "keep" /
+// unrecognised, matching the previous behaviour for the unconfigured case.
+func (f *Flasher) configureSPIForSize() error {
+	sizeBytes := uint32(4 * 1024 * 1024)
+	if b, ok := flashSizeStringToBytes(f.opts.FlashSize); ok {
+		sizeBytes = b
+	}
 	err := f.conn.spiSetParams(
-		4*1024*1024, // 4MB total
-		64*1024,     // 64KB block
-		4*1024,      // 4KB sector
-		256,         // 256B page
+		sizeBytes,
+		64*1024, // 64KB block
+		4*1024,  // 4KB sector
+		256,     // 256B page
 	)
 	if err != nil {
-		// Don't fail - some ROM versions don't support this
+		// Don't fail - some ROM versions don't support this.
 		f.logf("Warning: SPI params config failed (may be OK): %v", err)
 	}
-
 	return nil
+}
+
+// flashSizeStringToBytes converts a flash size string (e.g. "8MB") to the
+// chip capacity in bytes. Returns (0, false) for empty / "keep" / unknown
+// inputs so callers can apply a default.
+func flashSizeStringToBytes(s string) (uint32, bool) {
+	switch s {
+	case "1MB":
+		return 1 * 1024 * 1024, true
+	case "2MB":
+		return 2 * 1024 * 1024, true
+	case "4MB":
+		return 4 * 1024 * 1024, true
+	case "8MB":
+		return 8 * 1024 * 1024, true
+	case "16MB":
+		return 16 * 1024 * 1024, true
+	case "32MB":
+		return 32 * 1024 * 1024, true
+	case "64MB":
+		return 64 * 1024 * 1024, true
+	case "128MB":
+		return 128 * 1024 * 1024, true
+	}
+	return 0, false
 }
 
 // changeBaud switches to a higher baud rate for faster data transfer.


### PR DESCRIPTION
Fixes #41.

## What's wrong

`attachFlash` hardcodes `4*1024*1024` in `spiSetParams` regardless of `FlasherOptions.FlashSize` or what `detectFlashSize()` finds on the chip. The stub uses this value as a write bound — any write past 4 MB is rejected with `RESPONSE_FAILED_SPI_OP` (status `0xC4`).

Reproducible on ESP32-S3 with 8 MB flash by writing a partition at `0x6F0000`: the first compressed block fails with `command 0x11 failed: status=0xC4 error=0x00`. `esptool.py` and `esptool-js` both pass the real size to `SPI_SET_PARAMS` for this exact reason ([esptool/cmds.py:1852](https://github.com/espressif/esptool/blob/master/esptool/cmds.py#L1852) — *"the flash chip should be configured with the real size"*).

## What this PR does

- Adds `flashSizeStringToBytes` for the existing `1MB`..`128MB` size names.
- Splits `attachFlash` so the size step becomes a reusable `configureSPIForSize`.
- Re-runs `configureSPIForSize` after `detectFlashSize` in `FlashImages` so the stub gets the real chip size before the first write.
- Falls back to 4 MB when `FlashSize` is empty / `keep` / unrecognised — preserves prior behaviour for the unconfigured case.

## Test plan

- [x] `go test ./pkg/espflasher/` — all existing tests still pass.
- [x] Verified end-to-end on ESP32-S3 / 8 MB hardware that previously failed at `0x6F0000` with `status=0xC4`. With this patch the storage partition flashes through to MD5 verify.
- [ ] Would appreciate a second pair of eyes for ESP8266 (the new SPI re-config is gated behind `ChipType != ChipESP8266`, matching the ESP8266 short-circuit at the top of `attachFlash`).