### PR TITLE
fix: scale compressed-flash write/finish timeout by size

### DIFF
--- a/pkg/espflasher/protocol.go
+++ b/pkg/espflasher/protocol.go
@@ -88,6 +88,9 @@ type conn struct {
 	// (encrypted flag) in flash_begin/flash_defl_begin commands.
 	// Set based on chip type after detection.
 	supportsEncryptedFlash bool
+	// deflCompSize is the compressed size passed to the most recent
+	// flashDeflBegin call, used to scale the flashDeflEnd ack timeout.
+	deflCompSize uint32
 }
 
 // isStub returns whether the stub loader is running.
@@ -451,6 +454,10 @@ func (c *conn) flashDeflBegin(uncompSize, compSize, offset uint32, encrypted boo
 
 	timeout := eraseTimeoutForSize(uncompSize)
 
+	// Remember the compressed size for this download so flashDeflEnd can
+	// scale its own ack timeout the same way.
+	c.deflCompSize = compSize
+
 	// ESP32-S2 and newer ROM bootloaders support a 5th parameter (encrypted
 	// flag). ESP8266 and original ESP32 ROM only accept 4 parameters (16 bytes).
 	paramLen := 16
@@ -479,7 +486,8 @@ func (c *conn) flashDeflData(block []byte, seq uint32) error {
 	binary.LittleEndian.PutUint32(data[12:16], 0)
 	copy(data[16:], block)
 
-	_, err := c.checkCommand("write compressed flash block", cmdFlashDeflData, data, checksum(block), defaultTimeout, 0)
+	timeout := flashWriteTimeoutForSize(uint32(len(block)))
+	_, err := c.checkCommand("write compressed flash block", cmdFlashDeflData, data, checksum(block), timeout, 0)
 	return err
 }
 
@@ -490,7 +498,8 @@ func (c *conn) flashDeflEnd(reboot bool) error {
 		binary.LittleEndian.PutUint32(data, 1)
 	}
 
-	_, err := c.checkCommand("finish compressed flash download", cmdFlashDeflEnd, data, 0, defaultTimeout, 0)
+	timeout := flashWriteTimeoutForSize(c.deflCompSize)
+	_, err := c.checkCommand("finish compressed flash download", cmdFlashDeflEnd, data, 0, timeout, 0)
 	return err
 }
 
@@ -642,6 +651,20 @@ func eraseTimeoutForSize(size uint32) time.Duration {
 	t := defaultTimeout + time.Duration(float64(eraseWritePerMBRate)*float64(size)/float64(1024*1024))
 	if t < 10*time.Second {
 		t = 10 * time.Second
+	}
+	return t
+}
+
+// flashWriteTimeoutForSize calculates an appropriate ack timeout for
+// compressed flash write/finish commands, scaled by data size using the
+// same per-MB rate as eraseTimeoutForSize. Unlike erase (which floors at
+// 10s for a whole-region operation), write/finish acks are per-block or
+// per-image and use the smaller defaultTimeout floor so small writes
+// aren't over-inflated.
+func flashWriteTimeoutForSize(size uint32) time.Duration {
+	t := defaultTimeout + time.Duration(float64(eraseWritePerMBRate)*float64(size)/float64(1024*1024))
+	if t < defaultTimeout {
+		t = defaultTimeout
 	}
 	return t
 }

--- a/pkg/espflasher/protocol_test.go
+++ b/pkg/espflasher/protocol_test.go
@@ -108,6 +108,41 @@ func TestEraseTimeoutForSize(t *testing.T) {
 	}
 }
 
+func TestFlashWriteTimeoutForSize(t *testing.T) {
+	// E1-15 regression: compressed flash write/finish acks must scale by
+	// size (mirroring eraseTimeoutForSize), with a floor of defaultTimeout
+	// so small blocks aren't over-inflated.
+	tests := []struct {
+		name string
+		size uint32
+		min  time.Duration
+	}{
+		{"zero size has floor", 0, defaultTimeout},
+		{"small 4KB block has floor", 4096, defaultTimeout},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			timeout := flashWriteTimeoutForSize(tt.size)
+			if timeout < tt.min {
+				t.Errorf("flashWriteTimeoutForSize(%d) = %v, want >= %v", tt.size, timeout, tt.min)
+			}
+		})
+	}
+
+	// A 4MB compressed write must get a materially larger timeout than a
+	// 4KB block, so large transfers over slow USB-serial bridges don't
+	// time out on a flat ack wait.
+	small := flashWriteTimeoutForSize(4 * 1024)
+	large := flashWriteTimeoutForSize(4 * 1024 * 1024)
+	if large <= small {
+		t.Errorf("expected larger timeout for bigger size: small(4KB)=%v large(4MB)=%v", small, large)
+	}
+	if large < 2*small {
+		t.Errorf("expected 4MB timeout to be materially larger than 4KB timeout: small=%v large=%v", small, large)
+	}
+}
+
 func TestSendCommandFormat(t *testing.T) {
 	// Test that sendCommand builds the correct packet structure using a mock port.
 	var written []byte


### PR DESCRIPTION
The compressed-flash write and finish commands used a flat `defaultTimeout` (3s) regardless of payload size, while the erase path already scales its timeout by size via `eraseTimeoutForSize`. On some USB-UART bridges, a large compressed write (e.g. a 4 MB image) can exceed that flat timeout and fail with "timeout waiting for response to SLIP read", even though the flash operation itself is still progressing normally.

This fix mirrors the existing erase timeout-scaling approach for the compressed write/finish path, computing the timeout from the payload size and flooring it at the existing default so small writes are unaffected.

Verified on ESP32 hardware: a 4 MB flash image that previously timed out at default baud now completes successfully with this change.