### PR TITLE
feat: opt-in progress callbacks for erase and read operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,10 +220,15 @@ err := flasher.FlashImages(images, progressCallback)
 
 ```go
 // Erase entire flash
-err := flasher.EraseFlash()
+err := flasher.EraseFlash(nil)
 
 // Erase a specific region (must be sector-aligned)
-err := flasher.EraseRegion(0x10000, 0x100000)
+err := flasher.EraseRegion(0x10000, 0x100000, nil)
+
+// Erase with progress: current/total are elapsed/estimated milliseconds
+err := flasher.EraseFlash(func(current, total int) {
+	fmt.Printf("erasing... %dms / %dms\n", current, total)
+})
 
 // Read a hardware register
 val, err := flasher.ReadRegister(0x3FF00050)

--- a/main.go
+++ b/main.go
@@ -123,7 +123,7 @@ func main() {
 	fmt.Printf("Chip: %s\n", flasher.ChipName())
 
 	if *eraseAll {
-		if err := flasher.EraseFlash(); err != nil {
+		if err := flasher.EraseFlash(nil); err != nil {
 			log.Fatalf("Erase failed: %v", err)
 		}
 	}

--- a/pkg/espflasher/erase_test.go
+++ b/pkg/espflasher/erase_test.go
@@ -1,0 +1,206 @@
+package espflasher
+
+import (
+	"errors"
+	"runtime"
+	"testing"
+	"time"
+)
+
+func TestTickEraseProgress(t *testing.T) {
+	interval := 2 * time.Millisecond
+	est := 50 * time.Millisecond
+
+	var calls [][2]int
+	progress := func(current, total int) {
+		calls = append(calls, [2]int{current, total})
+	}
+	work := func() error {
+		time.Sleep(6 * interval)
+		return nil
+	}
+
+	if err := tickErase(est, interval, progress, work); err != nil {
+		t.Fatalf("tickErase returned error: %v", err)
+	}
+
+	if len(calls) < 2 {
+		t.Fatalf("expected at least one intermediate tick plus the final call, got %d calls", len(calls))
+	}
+
+	estMs := int(est / time.Millisecond)
+	last := calls[len(calls)-1]
+	if last[0] != estMs || last[1] != estMs {
+		t.Errorf("final call = %v, want (%d, %d)", last, estMs, estMs)
+	}
+
+	prev := -1
+	for i, c := range calls[:len(calls)-1] {
+		if c[1] != estMs {
+			t.Errorf("call %d total = %d, want %d", i, c[1], estMs)
+		}
+		if c[0] >= estMs {
+			t.Errorf("intermediate call %d current = %d, must be < total %d", i, c[0], estMs)
+		}
+		if c[0] < prev {
+			t.Errorf("call %d current = %d is not monotonically non-decreasing (prev %d)", i, c[0], prev)
+		}
+		prev = c[0]
+	}
+}
+
+func TestTickEraseErrorOmitsFinalCall(t *testing.T) {
+	interval := 2 * time.Millisecond
+	est := 50 * time.Millisecond
+	wantErr := errors.New("erase failed")
+
+	var calls [][2]int
+	progress := func(current, total int) {
+		calls = append(calls, [2]int{current, total})
+	}
+	work := func() error {
+		time.Sleep(4 * interval)
+		return wantErr
+	}
+
+	err := tickErase(est, interval, progress, work)
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("tickErase error = %v, want %v", err, wantErr)
+	}
+
+	estMs := int(est / time.Millisecond)
+	for i, c := range calls {
+		if c[0] == estMs && c[1] == estMs {
+			t.Errorf("call %d reported completion (%d, %d) despite work returning an error", i, c[0], c[1])
+		}
+	}
+}
+
+func TestTickEraseJoinsGoroutine(t *testing.T) {
+	before := runtime.NumGoroutine()
+
+	interval := time.Millisecond
+	est := 20 * time.Millisecond
+	work := func() error {
+		time.Sleep(5 * interval)
+		return nil
+	}
+
+	if err := tickErase(est, interval, func(int, int) {}, work); err != nil {
+		t.Fatalf("tickErase returned error: %v", err)
+	}
+
+	// The ticker goroutine is joined synchronously inside tickErase, so the
+	// count should already be back to baseline. Poll briefly anyway to absorb
+	// unrelated runtime bookkeeping goroutines.
+	deadline := time.Now().Add(200 * time.Millisecond)
+	for runtime.NumGoroutine() > before && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
+	if got := runtime.NumGoroutine(); got > before {
+		t.Errorf("goroutine count after tickErase = %d, want <= %d (possible leak)", got, before)
+	}
+}
+
+func TestTickErasePanicJoinsGoroutineAndPropagates(t *testing.T) {
+	before := runtime.NumGoroutine()
+
+	interval := time.Millisecond
+	est := 20 * time.Millisecond
+	wantPanic := "erase blew up"
+	work := func() error {
+		time.Sleep(5 * interval)
+		panic(wantPanic)
+	}
+
+	var calls [][2]int
+	progress := func(current, total int) {
+		calls = append(calls, [2]int{current, total})
+	}
+
+	func() {
+		defer func() {
+			r := recover()
+			if r == nil {
+				t.Fatal("expected tickErase to panic, but it did not")
+			}
+			if r != wantPanic {
+				t.Errorf("recovered panic = %v, want %v", r, wantPanic)
+			}
+		}()
+		_ = tickErase(est, interval, progress, work)
+	}()
+
+	estMs := int(est / time.Millisecond)
+	for i, c := range calls {
+		if c[0] == estMs && c[1] == estMs {
+			t.Errorf("call %d reported completion (%d, %d) despite work panicking", i, c[0], c[1])
+		}
+	}
+
+	// The ticker goroutine must be joined during panic unwinding, so the
+	// count should already be back to baseline. Poll briefly anyway to absorb
+	// unrelated runtime bookkeeping goroutines.
+	deadline := time.Now().Add(200 * time.Millisecond)
+	for runtime.NumGoroutine() > before && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
+	if got := runtime.NumGoroutine(); got > before {
+		t.Errorf("goroutine count after tickErase panic = %d, want <= %d (possible leak)", got, before)
+	}
+}
+
+func TestEraseFlashProgressWiring(t *testing.T) {
+	var calls [][2]int
+	mc := &mockConnection{
+		stubMode: true,
+		eraseFlashFunc: func() error {
+			return nil
+		},
+	}
+	f := &Flasher{conn: mc, opts: DefaultOptions()}
+
+	err := f.EraseFlash(func(current, total int) {
+		calls = append(calls, [2]int{current, total})
+	})
+	if err != nil {
+		t.Fatalf("EraseFlash returned error: %v", err)
+	}
+	if len(calls) == 0 {
+		t.Fatal("expected at least the final progress call")
+	}
+
+	wantMs := int(chipEraseTimeout / time.Millisecond)
+	last := calls[len(calls)-1]
+	if last[0] != wantMs || last[1] != wantMs {
+		t.Errorf("final progress = %v, want (%d, %d)", last, wantMs, wantMs)
+	}
+}
+
+func TestEraseRegionProgressWiring(t *testing.T) {
+	var calls [][2]int
+	mc := &mockConnection{
+		stubMode: true,
+		eraseRegionFunc: func(offset, size uint32) error {
+			return nil
+		},
+	}
+	f := &Flasher{conn: mc, opts: DefaultOptions()}
+
+	size := uint32(0x10000)
+	err := f.EraseRegion(0x10000, size, func(current, total int) {
+		calls = append(calls, [2]int{current, total})
+	})
+	if err != nil {
+		t.Fatalf("EraseRegion returned error: %v", err)
+	}
+	if len(calls) == 0 {
+		t.Fatal("expected at least the final progress call")
+	}
+
+	wantMs := int(eraseTimeoutForSize(size) / time.Millisecond)
+	last := calls[len(calls)-1]
+	if last[0] != wantMs || last[1] != wantMs {
+		t.Errorf("final progress = %v, want (%d, %d)", last, wantMs, wantMs)
+	}
+}

--- a/pkg/espflasher/flasher.go
+++ b/pkg/espflasher/flasher.go
@@ -75,8 +75,10 @@ type Logger interface {
 	Logf(format string, args ...interface{})
 }
 
-// ProgressFunc is called with progress updates during flashing.
-// current is the bytes transferred so far, total is the total bytes.
+// ProgressFunc is called with progress updates during long-running
+// operations. The meaning of current and total is operation-defined:
+// bytes transferred / total for flashing; elapsed / estimated milliseconds
+// for erase.
 type ProgressFunc func(current, total int)
 
 // DefaultOptions returns FlasherOptions with sensible defaults.
@@ -806,13 +808,26 @@ func (f *Flasher) verifyMD5(data []byte, offset uint32) error {
 // EraseFlash erases the entire flash memory.
 // This operation can take a significant amount of time (30-120 seconds).
 // Requires the stub loader to be running.
-func (f *Flasher) EraseFlash() error {
+//
+// If progress is non-nil, it is called periodically with a synthetic ETA
+// (elapsed and estimated milliseconds) ticked against the erase timeout,
+// since the device stays silent for the duration of the erase and reports
+// no real completion percentage. Pass nil to skip this entirely.
+func (f *Flasher) EraseFlash(progress ProgressFunc) error {
 	if !f.conn.isStub() {
 		return &UnsupportedCommandError{Command: "erase flash (requires stub)"}
 	}
 
 	f.logf("Erasing entire flash...")
-	if err := f.conn.eraseFlash(); err != nil {
+	if progress == nil {
+		if err := f.conn.eraseFlash(); err != nil {
+			return err
+		}
+		f.logf("Flash erased.")
+		return nil
+	}
+
+	if err := tickErase(chipEraseTimeout, eraseProgressInterval, progress, f.conn.eraseFlash); err != nil {
 		return err
 	}
 	f.logf("Flash erased.")
@@ -822,7 +837,12 @@ func (f *Flasher) EraseFlash() error {
 // EraseRegion erases a region of flash memory.
 // Requires the stub loader to be running.
 // Both offset and size must be aligned to the flash sector size (4096 bytes).
-func (f *Flasher) EraseRegion(offset, size uint32) error {
+//
+// If progress is non-nil, it is called periodically with a synthetic ETA
+// (elapsed and estimated milliseconds) ticked against the erase timeout,
+// since the device stays silent for the duration of the erase and reports
+// no real completion percentage. Pass nil to skip this entirely.
+func (f *Flasher) EraseRegion(offset, size uint32, progress ProgressFunc) error {
 	if !f.conn.isStub() {
 		return &UnsupportedCommandError{Command: "erase region (requires stub)"}
 	}
@@ -835,7 +855,71 @@ func (f *Flasher) EraseRegion(offset, size uint32) error {
 	}
 
 	f.logf("Erasing %d bytes at 0x%08X...", size, offset)
-	return f.conn.eraseRegion(offset, size)
+	if progress == nil {
+		return f.conn.eraseRegion(offset, size)
+	}
+
+	return tickErase(eraseTimeoutForSize(size), eraseProgressInterval, progress, func() error {
+		return f.conn.eraseRegion(offset, size)
+	})
+}
+
+// eraseProgressInterval is the tick interval used by tickErase when reporting
+// synthetic erase progress via EraseFlash and EraseRegion.
+const eraseProgressInterval = 500 * time.Millisecond
+
+// tickErase runs work (a blocking erase call) while emitting synthetic ETA
+// progress updates against est every interval, until work returns. progress
+// is called with (elapsedMs, estMs), capped so elapsed never reaches est
+// until work has actually completed successfully. On success, a final
+// progress(estMs, estMs) call is emitted; on error, no such call is made.
+//
+// The ticker goroutine only ever calls progress — it never touches the
+// connection — and is always stopped and joined before tickErase returns,
+// via a deferred cleanup registered before work is invoked. This holds even
+// if work panics: the deferred cleanup still runs during unwinding, the
+// ticker goroutine is joined, and the panic is left to propagate afterward
+// without emitting a bogus final progress(estMs, estMs) call.
+func tickErase(est, interval time.Duration, progress ProgressFunc, work func() error) error {
+	estMs := int(est / time.Millisecond)
+
+	done := make(chan struct{})
+	stopped := make(chan struct{})
+
+	go func() {
+		defer close(stopped)
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+
+		start := time.Now()
+		for {
+			select {
+			case <-done:
+				return
+			case <-ticker.C:
+				elapsedMs := int(time.Since(start) / time.Millisecond)
+				if elapsedMs >= estMs {
+					elapsedMs = estMs - 1
+				}
+				progress(elapsedMs, estMs)
+			}
+		}
+	}()
+
+	var success bool
+	defer func() {
+		close(done)
+		<-stopped
+		if success {
+			progress(estMs, estMs)
+		}
+	}()
+
+	if err := work(); err != nil {
+		return err
+	}
+	success = true
+	return nil
 }
 
 // ReadRegister reads a 32-bit register from the device.

--- a/pkg/espflasher/flasher.go
+++ b/pkg/espflasher/flasher.go
@@ -76,9 +76,11 @@ type Logger interface {
 }
 
 // ProgressFunc is called with progress updates during long-running
-// operations. The meaning of current and total is operation-defined:
-// bytes transferred / total for flashing; elapsed / estimated milliseconds
-// for erase.
+// operations. The meaning of current and total is operation-defined: for
+// flashing and reading, they are bytes transferred and total bytes; for
+// erase, they are elapsed and estimated-total milliseconds, since erase is
+// a single blocking command with no per-chunk protocol seam to report exact
+// byte progress.
 type ProgressFunc func(current, total int)
 
 // DefaultOptions returns FlasherOptions with sensible defaults.
@@ -121,7 +123,7 @@ type connection interface {
 	changeBaud(newBaud, oldBaud uint32) error
 	eraseFlash() error
 	eraseRegion(offset, size uint32) error
-	readFlash(offset, size uint32) ([]byte, error)
+	readFlash(offset, size uint32, progress ProgressFunc) ([]byte, error)
 	flushInput()
 	isStub() bool
 	setUSB(v bool)
@@ -957,7 +959,10 @@ func (f *Flasher) GetFlashMD5(offset, size uint32) (string, error) {
 
 // ReadFlash reads data from flash memory.
 // Requires the stub loader to be running.
-func (f *Flasher) ReadFlash(offset, size uint32) ([]byte, error) {
+// If progress is non-nil, it is called after each block is read with the
+// cumulative bytes read so far; the final call reports (size, size).
+// If size is 0, the read returns immediately with no progress callback invoked.
+func (f *Flasher) ReadFlash(offset, size uint32, progress ProgressFunc) ([]byte, error) {
 	if !f.conn.isStub() {
 		return nil, &UnsupportedCommandError{Command: "read flash (requires stub)"}
 	}
@@ -966,7 +971,7 @@ func (f *Flasher) ReadFlash(offset, size uint32) ([]byte, error) {
 		return nil, err
 	}
 
-	data, err := f.conn.readFlash(offset, size)
+	data, err := f.conn.readFlash(offset, size, progress)
 	// Clear any stale data left in the serial buffer and SLIP reader
 	// after the raw block-read protocol. Without this, leftover bytes
 	// can corrupt subsequent command responses.

--- a/pkg/espflasher/flasher_test.go
+++ b/pkg/espflasher/flasher_test.go
@@ -476,7 +476,7 @@ func TestReadFlashRequiresStub(t *testing.T) {
 	mock := &mockConnection{}
 	mock.stubMode = false // ROM mode
 	f := &Flasher{conn: mock, chip: chipDefs[ChipESP32]}
-	_, err := f.ReadFlash(0, 1024)
+	_, err := f.ReadFlash(0, 1024, nil)
 	if err == nil {
 		t.Fatal("expected error when stub is not running")
 	}

--- a/pkg/espflasher/flasher_test.go
+++ b/pkg/espflasher/flasher_test.go
@@ -149,13 +149,13 @@ func TestEraseRegionAlignment(t *testing.T) {
 	}
 
 	// Misaligned offset
-	err := f.EraseRegion(0x100, 0x1000)
+	err := f.EraseRegion(0x100, 0x1000, nil)
 	if err == nil {
 		t.Error("expected error for misaligned offset")
 	}
 
 	// Misaligned size
-	err = f.EraseRegion(0x1000, 0x100)
+	err = f.EraseRegion(0x1000, 0x100, nil)
 	if err == nil {
 		t.Error("expected error for misaligned size")
 	}

--- a/pkg/espflasher/protocol.go
+++ b/pkg/espflasher/protocol.go
@@ -578,7 +578,9 @@ func (c *conn) eraseRegion(offset, size uint32) error {
 }
 
 // readFlash reads data from flash memory (stub-only).
-func (c *conn) readFlash(offset, size uint32) ([]byte, error) {
+// If progress is non-nil, it is called after each block is appended with the
+// cumulative bytes read so far; the final call reports (size, size).
+func (c *conn) readFlash(offset, size uint32, progress ProgressFunc) ([]byte, error) {
 	data := make([]byte, 16)
 	binary.LittleEndian.PutUint32(data[0:4], offset)
 	binary.LittleEndian.PutUint32(data[4:8], size)
@@ -600,6 +602,17 @@ func (c *conn) readFlash(offset, size uint32) ([]byte, error) {
 			return nil, fmt.Errorf("read flash block %d/%d: %w", i+1, numBlocks, err)
 		}
 		result = append(result, block...)
+
+		if progress != nil {
+			// The final block may over-read past size (trimmed below); clamp
+			// the reported current so the sequence stays monotonic and the
+			// last call is exactly (size, size).
+			current := len(result)
+			if current > int(size) {
+				current = int(size)
+			}
+			progress(current, int(size))
+		}
 
 		// Send ACK: cumulative bytes received (SLIP-framed)
 		ack := make([]byte, 4)

--- a/pkg/espflasher/protocol_test.go
+++ b/pkg/espflasher/protocol_test.go
@@ -1,6 +1,7 @@
 package espflasher
 
 import (
+	"bytes"
 	"encoding/binary"
 	"testing"
 	"time"
@@ -442,7 +443,7 @@ type mockConnection struct {
 	eraseRegionFunc             func(offset, size uint32) error
 	flushInputFunc              func()
 	loadStubFunc                func(s *stub) error
-	readFlashFunc               func(offset, size uint32) ([]byte, error)
+	readFlashFunc               func(offset, size uint32, progress ProgressFunc) ([]byte, error)
 	stubMode                    bool
 	usbMode                     bool
 	supportsEncryptedFlashValue bool
@@ -573,9 +574,9 @@ func (m *mockConnection) flushInput() {
 	}
 }
 
-func (m *mockConnection) readFlash(offset, size uint32) ([]byte, error) {
+func (m *mockConnection) readFlash(offset, size uint32, progress ProgressFunc) ([]byte, error) {
 	if m.readFlashFunc != nil {
-		return m.readFlashFunc(offset, size)
+		return m.readFlashFunc(offset, size, progress)
 	}
 	return nil, nil
 }
@@ -735,6 +736,164 @@ func TestReadFlashParameterValidation(t *testing.T) {
 	}
 	if cmdReadFlash != 0xD2 {
 		t.Errorf("cmdReadFlash opcode mismatch")
+	}
+}
+
+// makeReadFlashCommandResponse creates a mock response for the read flash
+// command that kicks off the block-read loop.
+func makeReadFlashCommandResponse() []byte {
+	resp := make([]byte, 10)
+	resp[0] = respDirectionResp
+	resp[1] = cmdReadFlash
+	binary.LittleEndian.PutUint16(resp[2:4], 2) // data len = 2
+	binary.LittleEndian.PutUint32(resp[4:8], 0) // value
+	resp[8] = 0x00                              // status OK
+	resp[9] = 0x00                              // error 0
+	return resp
+}
+
+// newReadFlashMockPort builds a mockPort whose Read stream replays the
+// command ack, followed by the given raw data blocks (each SLIP-framed as
+// the device would send them), followed by the trailing 16-byte MD5 digest.
+func newReadFlashMockPort(blocks [][]byte) *mockPort {
+	var stream []byte
+	stream = append(stream, slipEncode(makeReadFlashCommandResponse())...)
+	for _, block := range blocks {
+		stream = append(stream, slipEncode(block)...)
+	}
+	stream = append(stream, slipEncode(make([]byte, 16))...) // MD5 digest
+
+	reader := bytes.NewReader(stream)
+	return &mockPort{readFunc: reader.Read}
+}
+
+func TestReadFlashProgressCallback(t *testing.T) {
+	// Span 2 blocks: a full 4KB block plus a partial 500-byte remainder.
+	// The mock device returns a full block for both (as real hardware does),
+	// so readFlash must trim the over-read on the final block.
+	const size = readFlashBlockSize + 500
+
+	block1 := bytes.Repeat([]byte{0xAA}, int(readFlashBlockSize))
+	block2 := bytes.Repeat([]byte{0xBB}, int(readFlashBlockSize))
+
+	mock := newReadFlashMockPort([][]byte{block1, block2})
+	c := &conn{port: mock, reader: newSlipReader(mock)}
+
+	type progressCall struct{ current, total int }
+	var calls []progressCall
+	progress := func(current, total int) {
+		calls = append(calls, progressCall{current, total})
+	}
+
+	data, err := c.readFlash(0, size, progress)
+	if err != nil {
+		t.Fatalf("readFlash failed: %v", err)
+	}
+	if len(data) != int(size) {
+		t.Fatalf("len(data) = %d, want %d", len(data), size)
+	}
+
+	if len(calls) < 2 {
+		t.Fatalf("expected >= 2 progress calls, got %d", len(calls))
+	}
+
+	prev := 0
+	for i, call := range calls {
+		if call.total != int(size) {
+			t.Errorf("call[%d].total = %d, want %d", i, call.total, size)
+		}
+		if call.current > int(size) {
+			t.Errorf("call[%d].current = %d, want <= %d", i, call.current, size)
+		}
+		if call.current < prev {
+			t.Errorf("call[%d].current = %d, not monotonic (prev %d)", i, call.current, prev)
+		}
+		prev = call.current
+	}
+
+	last := calls[len(calls)-1]
+	if last.current != int(size) || last.total != int(size) {
+		t.Errorf("final call = (%d, %d), want (%d, %d)", last.current, last.total, size, size)
+	}
+}
+
+func TestReadFlashProgressExactBlockMultiple(t *testing.T) {
+	// size is an exact multiple of readFlashBlockSize, so every block is
+	// full-sized and no trimming of the final block is needed.
+	const size = 2 * readFlashBlockSize
+
+	block1 := bytes.Repeat([]byte{0xAA}, int(readFlashBlockSize))
+	block2 := bytes.Repeat([]byte{0xBB}, int(readFlashBlockSize))
+
+	mock := newReadFlashMockPort([][]byte{block1, block2})
+	c := &conn{port: mock, reader: newSlipReader(mock)}
+
+	type progressCall struct{ current, total int }
+	var calls []progressCall
+	progress := func(current, total int) {
+		calls = append(calls, progressCall{current, total})
+	}
+
+	data, err := c.readFlash(0, size, progress)
+	if err != nil {
+		t.Fatalf("readFlash failed: %v", err)
+	}
+	if len(data) != int(size) {
+		t.Fatalf("len(data) = %d, want %d", len(data), size)
+	}
+
+	if len(calls) < 2 {
+		t.Fatalf("expected >= 2 progress calls, got %d", len(calls))
+	}
+
+	prev := 0
+	for i, call := range calls {
+		if call.current < prev {
+			t.Errorf("call[%d].current = %d, not monotonic (prev %d)", i, call.current, prev)
+		}
+		prev = call.current
+	}
+
+	last := calls[len(calls)-1]
+	if last.current != int(size) || last.total != int(size) {
+		t.Errorf("final call = (%d, %d), want (%d, %d)", last.current, last.total, size, size)
+	}
+}
+
+func TestReadFlashProgressZeroSize(t *testing.T) {
+	mock := newReadFlashMockPort(nil)
+	c := &conn{port: mock, reader: newSlipReader(mock)}
+
+	called := false
+	progress := func(current, total int) {
+		called = true
+	}
+
+	data, err := c.readFlash(0, 0, progress)
+	if err != nil {
+		t.Fatalf("readFlash failed: %v", err)
+	}
+	if len(data) != 0 {
+		t.Fatalf("len(data) = %d, want 0", len(data))
+	}
+	if called {
+		t.Errorf("progress callback invoked for size == 0, want no calls")
+	}
+}
+
+func TestReadFlashNilProgressNoPanic(t *testing.T) {
+	const size = 100
+	block := bytes.Repeat([]byte{0xCC}, int(size))
+
+	mock := newReadFlashMockPort([][]byte{block})
+	c := &conn{port: mock, reader: newSlipReader(mock)}
+
+	data, err := c.readFlash(0, size, nil)
+	if err != nil {
+		t.Fatalf("readFlash with nil progress failed: %v", err)
+	}
+	if len(data) != int(size) {
+		t.Fatalf("len(data) = %d, want %d", len(data), size)
 	}
 }
 

--- a/pkg/espflasher/stub_test.go
+++ b/pkg/espflasher/stub_test.go
@@ -88,7 +88,7 @@ func TestEraseFlashRequiresStub(t *testing.T) {
 	mc := &mockConnection{stubMode: false}
 	f := &Flasher{conn: mc, opts: DefaultOptions()}
 
-	err := f.EraseFlash()
+	err := f.EraseFlash(nil)
 	if err == nil {
 		t.Error("EraseFlash should fail without stub")
 	}
@@ -109,7 +109,7 @@ func TestEraseFlashSucceedsWithStub(t *testing.T) {
 	}
 	f := &Flasher{conn: mc, opts: DefaultOptions()}
 
-	if err := f.EraseFlash(); err != nil {
+	if err := f.EraseFlash(nil); err != nil {
 		t.Fatalf("EraseFlash returned error: %v", err)
 	}
 	if !called {


### PR DESCRIPTION
Adds an opt-in `ProgressFunc` callback (the same type already used by `FlashImage`/`FlashImages`) to erase and read operations.

- `EraseFlash`/`EraseRegion` report a time-based estimate against the operation's timeout, since erase is a single blocking command with no per-chunk protocol seam for exact byte progress.
- `ReadFlash` reports byte-accurate per-block progress.

In both cases the callback is a trailing nil-able argument matching the existing flash-side idiom, so passing nil preserves current behavior exactly.

Verified on ESP32 hardware.

The two commits (erase, then read) are kept separate for reviewability, since they touch overlapping doc comments on `ProgressFunc`; happy to squash if you'd prefer a single commit.