### PR TITLE
feat: add GPIO read/drive primitives for ESP32, ESP32-S2, ESP32-C3, ESP32-S3

### DIFF
--- a/pkg/espflasher/gpio.go
+++ b/pkg/espflasher/gpio.go
@@ -1,0 +1,401 @@
+package espflasher
+
+import "fmt"
+
+// GPIO register field constants shared across supported chips.
+const (
+	// ioMuxMCUSelShift is the bit offset of the MCU_SEL field within an
+	// IO_MUX pin configuration register.
+	ioMuxMCUSelShift = 12
+	// ioMuxMCUSelMask covers the 3-bit MCU_SEL field, bits[14:12].
+	ioMuxMCUSelMask = uint32(0x7) << ioMuxMCUSelShift
+	// ioMuxFunIEBit is the input-enable bit, bit[9].
+	ioMuxFunIEBit = uint32(1) << 9
+)
+
+// gpioChipDef holds the GPIO matrix and IO_MUX register layout for one chip
+// family. Only chips with a supported layout have an entry in gpioChipDefs.
+type gpioChipDef struct {
+	ioMuxBase uint32
+
+	outW1TS, outW1TC   uint32
+	out1W1TS, out1W1TC uint32 // 0 if the chip has no high-word registers
+
+	enableW1TS, enableW1TC   uint32
+	enable1W1TS, enable1W1TC uint32 // 0 if the chip has no high-word registers
+
+	in, in1 uint32 // in1 0 if the chip has no high-word register
+
+	hasHighWord bool // true if pins >31 exist and use the *1 registers
+
+	funcOutSelBase uint32 // FUNC0_OUT_SEL_CFG; stride +4/pin
+	outSelSentinel uint32 // direct GPIO-matrix output sentinel value
+	outSelMask     uint32 // low-field mask of FUNCn_OUT_SEL_CFG (bits holding OUT_SEL)
+
+	pinFuncGPIO uint32 // MCU_SEL value selecting the GPIO function
+	maxPin      int
+
+	ioMuxOffset map[int]uint32 // pin -> offset from ioMuxBase; absent = nonexistent
+	reserved    map[int]string // pin -> reservation class (includes input-only)
+	inputOnly   map[int]bool   // pins with no output driver
+}
+
+// gpioChipDefs maps supported chips to their GPIO register layouts.
+// Only ESP32, ESP32-S2, ESP32-C3, and ESP32-S3 are currently supported.
+var gpioChipDefs = map[ChipType]*gpioChipDef{
+	ChipESP32:   defESP32GPIO,
+	ChipESP32S2: defESP32S2GPIO,
+	ChipESP32C3: defESP32C3GPIO,
+	ChipESP32S3: defESP32S3GPIO,
+}
+
+var defESP32GPIO = &gpioChipDef{
+	ioMuxBase:      0x3FF49000,
+	outW1TS:        0x3FF44008,
+	outW1TC:        0x3FF4400C,
+	out1W1TS:       0x3FF44014,
+	out1W1TC:       0x3FF44018,
+	enableW1TS:     0x3FF44024,
+	enableW1TC:     0x3FF44028,
+	enable1W1TS:    0x3FF44030,
+	enable1W1TC:    0x3FF44034,
+	in:             0x3FF4403C,
+	in1:            0x3FF44040,
+	hasHighWord:    true,
+	funcOutSelBase: 0x3FF44530,
+	outSelSentinel: 256,
+	outSelMask:     0x1FF,
+	pinFuncGPIO:    2,
+	maxPin:         39,
+	ioMuxOffset: map[int]uint32{
+		0: 0x44, 1: 0x88, 2: 0x40, 3: 0x84, 4: 0x48, 5: 0x6c, 6: 0x60, 7: 0x64,
+		8: 0x68, 9: 0x54, 10: 0x58, 11: 0x5c, 12: 0x34, 13: 0x38, 14: 0x30, 15: 0x3c,
+		16: 0x4c, 17: 0x50, 18: 0x70, 19: 0x74, 21: 0x7c, 22: 0x80, 23: 0x8c,
+		25: 0x24, 26: 0x28, 27: 0x2c,
+		32: 0x1c, 33: 0x20, 34: 0x14, 35: 0x18, 36: 0x04, 37: 0x08, 38: 0x0c, 39: 0x10,
+		// Pin 20 exists only on PICO-package variants; treated as nonexistent
+		// since the flasher cannot distinguish package variants.
+		// Pins 24, 28-31 do not exist on any ESP32 package.
+	},
+	reserved: map[int]string{
+		6: "flash", 7: "flash", 8: "flash", 9: "flash", 10: "flash", 11: "flash",
+		0: "strap", 2: "strap", 5: "strap", 12: "strap", 15: "strap",
+		1: "uart0", 3: "uart0",
+		34: "input-only", 35: "input-only", 36: "input-only", 37: "input-only",
+		38: "input-only", 39: "input-only",
+	},
+	inputOnly: map[int]bool{34: true, 35: true, 36: true, 37: true, 38: true, 39: true},
+}
+
+var defESP32S2GPIO = &gpioChipDef{
+	ioMuxBase:      0x3F409000,
+	outW1TS:        0x3F404008,
+	outW1TC:        0x3F40400C,
+	out1W1TS:       0x3F404014,
+	out1W1TC:       0x3F404018,
+	enableW1TS:     0x3F404024,
+	enableW1TC:     0x3F404028,
+	enable1W1TS:    0x3F404030,
+	enable1W1TC:    0x3F404034,
+	in:             0x3F40403C,
+	in1:            0x3F404040,
+	hasHighWord:    true,
+	funcOutSelBase: 0x3F404554,
+	outSelSentinel: 256,
+	outSelMask:     0x1FF,
+	pinFuncGPIO:    1,
+	maxPin:         46,
+	ioMuxOffset:    esp32s2IOMuxOffsets(),
+	reserved: map[int]string{
+		26: "flash/psram", 27: "flash/psram", 28: "flash/psram", 29: "flash/psram",
+		30: "flash/psram", 31: "flash/psram", 32: "flash/psram",
+		0: "strap", 45: "strap", 46: "strap",
+		43: "uart0", 44: "uart0",
+		// 46 is both a strap and input-only; reserved map keeps the strap
+		// classification, inputOnly below still gates SetGPIO independently.
+	},
+	inputOnly: map[int]bool{46: true},
+}
+
+// esp32s2IOMuxOffsets builds the ESP32-S2 IO_MUX pin offset table:
+// pins 0-21 are linear (0x04 + 4*n), pins 26-46 are linear from a different
+// base (0x6C + 4*(n-26)). Pins 22-25 do not exist.
+func esp32s2IOMuxOffsets() map[int]uint32 {
+	offs := make(map[int]uint32, 22+21)
+	for n := 0; n <= 21; n++ {
+		offs[n] = 0x04 + 4*uint32(n)
+	}
+	for n := 26; n <= 46; n++ {
+		offs[n] = 0x6C + 4*uint32(n-26)
+	}
+	return offs
+}
+
+var defESP32C3GPIO = &gpioChipDef{
+	ioMuxBase:      0x60009000,
+	outW1TS:        0x60004008,
+	outW1TC:        0x6000400C,
+	enableW1TS:     0x60004024,
+	enableW1TC:     0x60004028,
+	in:             0x6000403C,
+	hasHighWord:    false,
+	funcOutSelBase: 0x60004554,
+	outSelSentinel: 128,
+	outSelMask:     0xFF,
+	pinFuncGPIO:    1,
+	maxPin:         21,
+	ioMuxOffset:    esp32c3IOMuxOffsets(),
+	reserved: map[int]string{
+		12: "flash", 13: "flash", 14: "flash", 15: "flash", 16: "flash", 17: "flash",
+		2: "strap", 8: "strap", 9: "strap",
+		11: "vdd-spi",
+		18: "usb-jtag", 19: "usb-jtag",
+		20: "uart0", 21: "uart0",
+	},
+	inputOnly: map[int]bool{},
+}
+
+// esp32c3IOMuxOffsets builds the ESP32-C3 IO_MUX pin offset table: linear,
+// IO_MUX_GPIOn = 0x04 + 4*n for n=0..21.
+func esp32c3IOMuxOffsets() map[int]uint32 {
+	offs := make(map[int]uint32, 22)
+	for n := 0; n <= 21; n++ {
+		offs[n] = 0x04 + 4*uint32(n)
+	}
+	return offs
+}
+
+var defESP32S3GPIO = &gpioChipDef{
+	ioMuxBase:      0x60009000,
+	outW1TS:        0x60004008,
+	outW1TC:        0x6000400C,
+	out1W1TS:       0x60004014,
+	out1W1TC:       0x60004018,
+	enableW1TS:     0x60004024,
+	enableW1TC:     0x60004028,
+	enable1W1TS:    0x60004030,
+	enable1W1TC:    0x60004034,
+	in:             0x6000403C,
+	in1:            0x60004040,
+	hasHighWord:    true,
+	funcOutSelBase: 0x60004554,
+	outSelSentinel: 256,
+	outSelMask:     0x1FF,
+	pinFuncGPIO:    1,
+	maxPin:         48,
+	ioMuxOffset:    esp32s3IOMuxOffsets(),
+	reserved: map[int]string{
+		26: "flash/psram", 27: "flash/psram", 28: "flash/psram", 29: "flash/psram", 30: "flash/psram", 31: "flash/psram", 32: "flash/psram",
+		33: "flash/psram", 34: "flash/psram", 35: "flash/psram", 36: "flash/psram", 37: "flash/psram",
+		47: "differential-clock octal PSRAM", 48: "differential-clock octal PSRAM",
+		0: "strap", 3: "strap", 45: "strap", 46: "strap",
+		19: "usb-jtag", 20: "usb-jtag",
+		43: "uart0", 44: "uart0",
+		// JTAG pins 39-42 are intentionally left unreserved: drivable as
+		// free GPIO when no debugger is attached.
+	},
+	inputOnly: map[int]bool{},
+}
+
+// esp32s3IOMuxOffsets builds the ESP32-S3 IO_MUX pin offset table: linear,
+// IO_MUX_GPIOn = 0x04 + 4*n for n in {0..21, 26..48}. Pins 22-25 do not exist.
+func esp32s3IOMuxOffsets() map[int]uint32 {
+	offs := make(map[int]uint32, 22+23)
+	for n := 0; n <= 21; n++ {
+		offs[n] = 0x04 + 4*uint32(n)
+	}
+	for n := 26; n <= 48; n++ {
+		offs[n] = 0x04 + 4*uint32(n)
+	}
+	return offs
+}
+
+// gpioDefFor returns the GPIO register layout for f's connected chip, or an
+// error if the chip is not supported for GPIO operations.
+func (f *Flasher) gpioDefFor() (*gpioChipDef, error) {
+	ct := f.ChipType()
+	def, ok := gpioChipDefs[ct]
+	if !ok {
+		return nil, fmt.Errorf("GPIO not supported for %s", ct)
+	}
+	return def, nil
+}
+
+// resolvePin validates that pin exists on the chip and returns its IO_MUX
+// register address.
+func (d *gpioChipDef) resolvePin(pin int) (ioMuxAddr uint32, err error) {
+	if pin < 0 || pin > d.maxPin {
+		return 0, fmt.Errorf("pin %d does not exist", pin)
+	}
+	off, ok := d.ioMuxOffset[pin]
+	if !ok {
+		return 0, fmt.Errorf("pin %d does not exist", pin)
+	}
+	return d.ioMuxBase + off, nil
+}
+
+// outEnableRegs returns the OUT_W1TS/W1TC and ENABLE_W1TS/W1TC register
+// addresses and bit index to use for pin (selecting the *1 high-word
+// registers for pin >31 on chips that have them).
+func (d *gpioChipDef) outEnableRegs(pin int) (outW1TS, outW1TC, enW1TS, enW1TC uint32, bit uint32) {
+	if pin >= 32 && d.hasHighWord {
+		return d.out1W1TS, d.out1W1TC, d.enable1W1TS, d.enable1W1TC, uint32(pin - 32)
+	}
+	return d.outW1TS, d.outW1TC, d.enableW1TS, d.enableW1TC, uint32(pin)
+}
+
+// inReg returns the IN/IN1 register address and bit index to use for pin.
+func (d *gpioChipDef) inReg(pin int) (addr uint32, bit uint32) {
+	if pin >= 32 && d.hasHighWord {
+		return d.in1, uint32(pin - 32)
+	}
+	return d.in, uint32(pin)
+}
+
+// funcOutSelAddr returns the FUNCn_OUT_SEL_CFG register address for pin.
+func (d *gpioChipDef) funcOutSelAddr(pin int) uint32 {
+	return d.funcOutSelBase + 4*uint32(pin)
+}
+
+// ReadGPIO configures pin as a GPIO input and returns its current level.
+func (f *Flasher) ReadGPIO(pin int) (bool, error) {
+	def, err := f.gpioDefFor()
+	if err != nil {
+		return false, err
+	}
+	ioMuxAddr, err := def.resolvePin(pin)
+	if err != nil {
+		return false, err
+	}
+
+	// RMW IO_MUX: MCU_SEL = PIN_FUNC_GPIO, FUN_IE = 1.
+	val, err := f.conn.readReg(ioMuxAddr)
+	if err != nil {
+		return false, fmt.Errorf("read IO_MUX for pin %d: %w", pin, err)
+	}
+	val = (val &^ ioMuxMCUSelMask) | (def.pinFuncGPIO << ioMuxMCUSelShift)
+	val |= ioMuxFunIEBit
+	if err := f.conn.writeReg(ioMuxAddr, val, 0xFFFFFFFF, 0); err != nil {
+		return false, fmt.Errorf("write IO_MUX for pin %d: %w", pin, err)
+	}
+
+	// Ensure the output driver is disabled so a prior SetGPIO (without a
+	// matching ReleaseGPIO) cannot make this read observe the flasher's own
+	// driven value instead of the pin's true input level.
+	_, _, _, enW1TC, bit := def.outEnableRegs(pin)
+	if err := f.conn.writeReg(enW1TC, 1<<bit, 0xFFFFFFFF, 0); err != nil {
+		return false, fmt.Errorf("disable output for pin %d: %w", pin, err)
+	}
+
+	inAddr, bit := def.inReg(pin)
+	inVal, err := f.conn.readReg(inAddr)
+	if err != nil {
+		return false, fmt.Errorf("read IN for pin %d: %w", pin, err)
+	}
+	return inVal&(1<<bit) != 0, nil
+}
+
+// SetGPIO configures pin as a GPIO output and drives it to level.
+// Input-only pins and pins that do not exist are refused.
+func (f *Flasher) SetGPIO(pin int, level bool) error {
+	def, err := f.gpioDefFor()
+	if err != nil {
+		return err
+	}
+	ioMuxAddr, err := def.resolvePin(pin)
+	if err != nil {
+		return err
+	}
+	if def.inputOnly[pin] {
+		return fmt.Errorf("pin %d is input-only", pin)
+	}
+
+	// RMW IO_MUX: MCU_SEL = PIN_FUNC_GPIO.
+	val, err := f.conn.readReg(ioMuxAddr)
+	if err != nil {
+		return fmt.Errorf("read IO_MUX for pin %d: %w", pin, err)
+	}
+	val = (val &^ ioMuxMCUSelMask) | (def.pinFuncGPIO << ioMuxMCUSelShift)
+	if err := f.conn.writeReg(ioMuxAddr, val, 0xFFFFFFFF, 0); err != nil {
+		return fmt.Errorf("write IO_MUX for pin %d: %w", pin, err)
+	}
+
+	// RMW FUNCn_OUT_SEL_CFG: low field = direct-GPIO sentinel.
+	selAddr := def.funcOutSelAddr(pin)
+	selVal, err := f.conn.readReg(selAddr)
+	if err != nil {
+		return fmt.Errorf("read OUT_SEL for pin %d: %w", pin, err)
+	}
+	selVal = (selVal &^ def.outSelMask) | (def.outSelSentinel & def.outSelMask)
+	if err := f.conn.writeReg(selAddr, selVal, 0xFFFFFFFF, 0); err != nil {
+		return fmt.Errorf("write OUT_SEL for pin %d: %w", pin, err)
+	}
+
+	outW1TS, outW1TC, enW1TS, _, bit := def.outEnableRegs(pin)
+
+	// Set the level first, then enable the output driver.
+	if level {
+		if err := f.conn.writeReg(outW1TS, 1<<bit, 0xFFFFFFFF, 0); err != nil {
+			return fmt.Errorf("set OUT for pin %d: %w", pin, err)
+		}
+	} else {
+		if err := f.conn.writeReg(outW1TC, 1<<bit, 0xFFFFFFFF, 0); err != nil {
+			return fmt.Errorf("clear OUT for pin %d: %w", pin, err)
+		}
+	}
+
+	if err := f.conn.writeReg(enW1TS, 1<<bit, 0xFFFFFFFF, 0); err != nil {
+		return fmt.Errorf("enable output for pin %d: %w", pin, err)
+	}
+	return nil
+}
+
+// ReleaseGPIO disables the output driver on pin and leaves it readable as
+// an input. MCU_SEL and OUT_SEL are left as-is.
+func (f *Flasher) ReleaseGPIO(pin int) error {
+	def, err := f.gpioDefFor()
+	if err != nil {
+		return err
+	}
+	ioMuxAddr, err := def.resolvePin(pin)
+	if err != nil {
+		return err
+	}
+
+	_, _, _, enW1TC, bit := def.outEnableRegs(pin)
+	if err := f.conn.writeReg(enW1TC, 1<<bit, 0xFFFFFFFF, 0); err != nil {
+		return fmt.Errorf("disable output for pin %d: %w", pin, err)
+	}
+
+	val, err := f.conn.readReg(ioMuxAddr)
+	if err != nil {
+		return fmt.Errorf("read IO_MUX for pin %d: %w", pin, err)
+	}
+	val |= ioMuxFunIEBit
+	if err := f.conn.writeReg(ioMuxAddr, val, 0xFFFFFFFF, 0); err != nil {
+		return fmt.Errorf("write IO_MUX for pin %d: %w", pin, err)
+	}
+	return nil
+}
+
+// GPIOReserved reports whether pin is reserved for a chip function that
+// makes driving it unsafe or meaningless (nonexistent, flash/PSRAM, strapping,
+// input-only, active UART0, or USB-JTAG), along with a short reason. It does
+// not block SetGPIO/ReadGPIO/ReleaseGPIO except for nonexistent and
+// input-only pins (SetGPIO) — callers decide whether to gate on the rest.
+func (f *Flasher) GPIOReserved(pin int) (bool, string) {
+	def, err := f.gpioDefFor()
+	if err != nil {
+		return true, err.Error()
+	}
+	if _, err := def.resolvePin(pin); err != nil {
+		return true, "nonexistent"
+	}
+	if reason, ok := def.reserved[pin]; ok {
+		return true, reason
+	}
+	if def.inputOnly[pin] {
+		return true, "input-only"
+	}
+	return false, ""
+}

--- a/pkg/espflasher/gpio_test.go
+++ b/pkg/espflasher/gpio_test.go
@@ -1,0 +1,856 @@
+package espflasher
+
+import (
+	"errors"
+	"testing"
+)
+
+// regOp records a single ordered register operation performed through the
+// connection interface.
+type regOp struct {
+	op   string // "r" (readReg) or "w" (writeReg)
+	addr uint32
+	val  uint32 // only meaningful for "w"
+}
+
+// newRecordingConn returns a mockConnection whose readReg always returns 0
+// and whose readReg/writeReg calls are recorded in order, along with the
+// backing slice.
+func newRecordingConn() (*mockConnection, *[]regOp) {
+	ops := &[]regOp{}
+	mc := &mockConnection{}
+	mc.readRegFunc = func(addr uint32) (uint32, error) {
+		*ops = append(*ops, regOp{op: "r", addr: addr})
+		return 0, nil
+	}
+	mc.writeRegFunc = func(addr, value, mask, delayUS uint32) error {
+		*ops = append(*ops, regOp{op: "w", addr: addr, val: value})
+		return nil
+	}
+	return mc, ops
+}
+
+func flasherFor(ct ChipType, mc *mockConnection) *Flasher {
+	return &Flasher{conn: mc, chip: &chipDef{ChipType: ct}, opts: DefaultOptions()}
+}
+
+func assertOps(t *testing.T, got []regOp, want []regOp) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("op count = %d, want %d\ngot:  %+v\nwant: %+v", len(got), len(want), got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("op[%d] = %+v, want %+v", i, got[i], want[i])
+		}
+	}
+}
+
+// --- ESP32, pin 16: PIN_FUNC_GPIO=2, IO_MUX offset 0x4c, pin <32 ---
+
+const (
+	esp32Pin16IOMux  = 0x3FF49000 + 0x4c
+	esp32Pin16OutSel = 0x3FF44530 + 4*16
+)
+
+func TestSetGPIOESP32High(t *testing.T) {
+	mc, ops := newRecordingConn()
+	f := flasherFor(ChipESP32, mc)
+
+	if err := f.SetGPIO(16, true); err != nil {
+		t.Fatalf("SetGPIO: %v", err)
+	}
+	assertOps(t, *ops, []regOp{
+		{"r", esp32Pin16IOMux, 0},
+		{"w", esp32Pin16IOMux, 2 << 12},
+		{"r", esp32Pin16OutSel, 0},
+		{"w", esp32Pin16OutSel, 256},
+		{"w", 0x3FF44008, 1 << 16}, // OUT_W1TS
+		{"w", 0x3FF44024, 1 << 16}, // ENABLE_W1TS
+	})
+}
+
+func TestSetGPIOESP32Low(t *testing.T) {
+	mc, ops := newRecordingConn()
+	f := flasherFor(ChipESP32, mc)
+
+	if err := f.SetGPIO(16, false); err != nil {
+		t.Fatalf("SetGPIO: %v", err)
+	}
+	assertOps(t, *ops, []regOp{
+		{"r", esp32Pin16IOMux, 0},
+		{"w", esp32Pin16IOMux, 2 << 12},
+		{"r", esp32Pin16OutSel, 0},
+		{"w", esp32Pin16OutSel, 256},
+		{"w", 0x3FF4400C, 1 << 16}, // OUT_W1TC
+		{"w", 0x3FF44024, 1 << 16}, // ENABLE_W1TS
+	})
+}
+
+func TestReadGPIOESP32(t *testing.T) {
+	mc, ops := newRecordingConn()
+	f := flasherFor(ChipESP32, mc)
+
+	v, err := f.ReadGPIO(16)
+	if err != nil {
+		t.Fatalf("ReadGPIO: %v", err)
+	}
+	if v {
+		t.Error("expected level false (mock IN reads 0)")
+	}
+	assertOps(t, *ops, []regOp{
+		{"r", esp32Pin16IOMux, 0},
+		{"w", esp32Pin16IOMux, (2 << 12) | ioMuxFunIEBit},
+		{"w", 0x3FF44028, 1 << 16}, // ENABLE_W1TC
+		{"r", 0x3FF4403C, 0},       // IN
+	})
+}
+
+func TestReleaseGPIOESP32(t *testing.T) {
+	mc, ops := newRecordingConn()
+	f := flasherFor(ChipESP32, mc)
+
+	if err := f.ReleaseGPIO(16); err != nil {
+		t.Fatalf("ReleaseGPIO: %v", err)
+	}
+	assertOps(t, *ops, []regOp{
+		{"w", 0x3FF44028, 1 << 16}, // ENABLE_W1TC
+		{"r", esp32Pin16IOMux, 0},
+		{"w", esp32Pin16IOMux, ioMuxFunIEBit},
+	})
+}
+
+func TestESP32GPIO2NonLinearIOMuxOffset(t *testing.T) {
+	mc, ops := newRecordingConn()
+	f := flasherFor(ChipESP32, mc)
+
+	if _, err := f.ReadGPIO(2); err != nil {
+		t.Fatalf("ReadGPIO: %v", err)
+	}
+	wantAddr := uint32(0x3FF49000 + 0x40)
+	if (*ops)[0].addr != wantAddr {
+		t.Errorf("GPIO2 IO_MUX addr = %#x, want %#x", (*ops)[0].addr, wantAddr)
+	}
+}
+
+// --- ESP32, pin 32: high-word regs (OUT1/ENABLE1/IN1), PIN_FUNC_GPIO=2 ---
+
+const (
+	esp32Pin32IOMux  = 0x3FF49000 + 0x1c
+	esp32Pin32OutSel = 0x3FF44530 + 4*32
+)
+
+func TestSetGPIOESP32HighWordPin(t *testing.T) {
+	mc, ops := newRecordingConn()
+	f := flasherFor(ChipESP32, mc)
+
+	if err := f.SetGPIO(32, true); err != nil {
+		t.Fatalf("SetGPIO: %v", err)
+	}
+	assertOps(t, *ops, []regOp{
+		{"r", esp32Pin32IOMux, 0},
+		{"w", esp32Pin32IOMux, 2 << 12},
+		{"r", esp32Pin32OutSel, 0},
+		{"w", esp32Pin32OutSel, 256},
+		{"w", 0x3FF44014, 1 << 0}, // OUT1_W1TS, bit = 32-32
+		{"w", 0x3FF44030, 1 << 0}, // ENABLE1_W1TS
+	})
+}
+
+func TestReadGPIOESP32HighWordPin(t *testing.T) {
+	mc, ops := newRecordingConn()
+	f := flasherFor(ChipESP32, mc)
+
+	if _, err := f.ReadGPIO(32); err != nil {
+		t.Fatalf("ReadGPIO: %v", err)
+	}
+	assertOps(t, *ops, []regOp{
+		{"r", esp32Pin32IOMux, 0},
+		{"w", esp32Pin32IOMux, (2 << 12) | ioMuxFunIEBit},
+		{"w", 0x3FF44034, 1 << 0}, // ENABLE1_W1TC
+		{"r", 0x3FF44040, 0},      // IN1
+	})
+}
+
+func TestReleaseGPIOESP32HighWordPin(t *testing.T) {
+	mc, ops := newRecordingConn()
+	f := flasherFor(ChipESP32, mc)
+
+	if err := f.ReleaseGPIO(32); err != nil {
+		t.Fatalf("ReleaseGPIO: %v", err)
+	}
+	assertOps(t, *ops, []regOp{
+		{"w", 0x3FF44034, 1 << 0}, // ENABLE1_W1TC
+		{"r", esp32Pin32IOMux, 0},
+		{"w", esp32Pin32IOMux, ioMuxFunIEBit},
+	})
+}
+
+// --- ESP32-S2, pin 33: high-word regs (OUT1/ENABLE1/IN1), PIN_FUNC_GPIO=1 ---
+
+const (
+	s2Pin33IOMux  = 0x3F409000 + 0x88
+	s2Pin33OutSel = 0x3F404554 + 4*33
+)
+
+func TestSetGPIOS2HighWordPin(t *testing.T) {
+	mc, ops := newRecordingConn()
+	f := flasherFor(ChipESP32S2, mc)
+
+	if err := f.SetGPIO(33, true); err != nil {
+		t.Fatalf("SetGPIO: %v", err)
+	}
+	assertOps(t, *ops, []regOp{
+		{"r", s2Pin33IOMux, 0},
+		{"w", s2Pin33IOMux, 1 << 12},
+		{"r", s2Pin33OutSel, 0},
+		{"w", s2Pin33OutSel, 256},
+		{"w", 0x3F404014, 1 << 1}, // OUT1_W1TS, bit = 33-32
+		{"w", 0x3F404030, 1 << 1}, // ENABLE1_W1TS
+	})
+}
+
+func TestReadGPIOS2HighWordPin(t *testing.T) {
+	mc, ops := newRecordingConn()
+	f := flasherFor(ChipESP32S2, mc)
+
+	if _, err := f.ReadGPIO(33); err != nil {
+		t.Fatalf("ReadGPIO: %v", err)
+	}
+	assertOps(t, *ops, []regOp{
+		{"r", s2Pin33IOMux, 0},
+		{"w", s2Pin33IOMux, (1 << 12) | ioMuxFunIEBit},
+		{"w", 0x3F404034, 1 << 1}, // ENABLE1_W1TC, bit = 33-32
+		{"r", 0x3F404040, 0},      // IN1
+	})
+}
+
+func TestReleaseGPIOS2HighWordPin(t *testing.T) {
+	mc, ops := newRecordingConn()
+	f := flasherFor(ChipESP32S2, mc)
+
+	if err := f.ReleaseGPIO(33); err != nil {
+		t.Fatalf("ReleaseGPIO: %v", err)
+	}
+	assertOps(t, *ops, []regOp{
+		{"w", 0x3F404034, 1 << 1}, // ENABLE1_W1TC
+		{"r", s2Pin33IOMux, 0},
+		{"w", s2Pin33IOMux, ioMuxFunIEBit},
+	})
+}
+
+// --- ESP32-C3, pin 5: sentinel 128, PIN_FUNC_GPIO=1, no high-word regs ---
+
+const (
+	c3Pin5IOMux  = 0x60009000 + 0x18
+	c3Pin5OutSel = 0x60004554 + 4*5
+)
+
+func TestSetGPIOC3Sentinel(t *testing.T) {
+	mc, ops := newRecordingConn()
+	f := flasherFor(ChipESP32C3, mc)
+
+	if err := f.SetGPIO(5, true); err != nil {
+		t.Fatalf("SetGPIO: %v", err)
+	}
+	assertOps(t, *ops, []regOp{
+		{"r", c3Pin5IOMux, 0},
+		{"w", c3Pin5IOMux, 1 << 12},
+		{"r", c3Pin5OutSel, 0},
+		{"w", c3Pin5OutSel, 128},
+		{"w", 0x60004008, 1 << 5}, // OUT_W1TS
+		{"w", 0x60004024, 1 << 5}, // ENABLE_W1TS
+	})
+}
+
+func TestReadGPIOC3(t *testing.T) {
+	mc, ops := newRecordingConn()
+	f := flasherFor(ChipESP32C3, mc)
+
+	if _, err := f.ReadGPIO(5); err != nil {
+		t.Fatalf("ReadGPIO: %v", err)
+	}
+	assertOps(t, *ops, []regOp{
+		{"r", c3Pin5IOMux, 0},
+		{"w", c3Pin5IOMux, (1 << 12) | ioMuxFunIEBit},
+		{"w", 0x60004028, 1 << 5}, // ENABLE_W1TC
+		{"r", 0x6000403C, 0},      // IN
+	})
+}
+
+func TestReleaseGPIOC3(t *testing.T) {
+	mc, ops := newRecordingConn()
+	f := flasherFor(ChipESP32C3, mc)
+
+	if err := f.ReleaseGPIO(5); err != nil {
+		t.Fatalf("ReleaseGPIO: %v", err)
+	}
+	assertOps(t, *ops, []regOp{
+		{"w", 0x60004028, 1 << 5}, // ENABLE_W1TC
+		{"r", c3Pin5IOMux, 0},
+		{"w", c3Pin5IOMux, ioMuxFunIEBit},
+	})
+}
+
+func TestC3GPIO5LinearIOMuxOffset(t *testing.T) {
+	mc, ops := newRecordingConn()
+	f := flasherFor(ChipESP32C3, mc)
+
+	if _, err := f.ReadGPIO(5); err != nil {
+		t.Fatalf("ReadGPIO: %v", err)
+	}
+	wantAddr := uint32(0x60009000 + 0x18)
+	if (*ops)[0].addr != wantAddr {
+		t.Errorf("GPIO5 IO_MUX addr = %#x, want %#x", (*ops)[0].addr, wantAddr)
+	}
+}
+
+// --- Input-only pins must refuse SetGPIO ---
+
+func TestSetGPIOInputOnlyRefused(t *testing.T) {
+	cases := []struct {
+		chip ChipType
+		pin  int
+	}{
+		{ChipESP32, 34},
+		{ChipESP32, 39},
+		{ChipESP32S2, 46},
+	}
+	for _, c := range cases {
+		mc, _ := newRecordingConn()
+		f := flasherFor(c.chip, mc)
+		if err := f.SetGPIO(c.pin, true); err == nil {
+			t.Errorf("%s pin %d: expected error for input-only pin", c.chip, c.pin)
+		}
+	}
+}
+
+// --- Nonexistent pins error on every method ---
+
+func TestNonexistentPinErrorsOnAllMethods(t *testing.T) {
+	cases := []struct {
+		chip ChipType
+		pin  int
+	}{
+		{ChipESP32, 24},
+		{ChipESP32, 20},
+		{ChipESP32, 28},
+		{ChipESP32S2, 22},
+		{ChipESP32S2, 25},
+	}
+	for _, c := range cases {
+		mc, _ := newRecordingConn()
+		f := flasherFor(c.chip, mc)
+
+		if err := f.SetGPIO(c.pin, true); err == nil {
+			t.Errorf("%s pin %d: SetGPIO expected error", c.chip, c.pin)
+		}
+		if _, err := f.ReadGPIO(c.pin); err == nil {
+			t.Errorf("%s pin %d: ReadGPIO expected error", c.chip, c.pin)
+		}
+		if err := f.ReleaseGPIO(c.pin); err == nil {
+			t.Errorf("%s pin %d: ReleaseGPIO expected error", c.chip, c.pin)
+		}
+		reserved, reason := f.GPIOReserved(c.pin)
+		if !reserved || reason != "nonexistent" {
+			t.Errorf("%s pin %d: GPIOReserved = (%v, %q), want (true, \"nonexistent\")", c.chip, c.pin, reserved, reason)
+		}
+	}
+}
+
+// --- GPIOReserved classifications ---
+
+func TestGPIOReservedClassifications(t *testing.T) {
+	cases := []struct {
+		chip ChipType
+		pin  int
+		want string
+	}{
+		{ChipESP32, 6, "flash"},
+		{ChipESP32, 0, "strap"},
+		{ChipESP32, 1, "uart0"},
+		{ChipESP32, 34, "input-only"},
+		{ChipESP32S2, 26, "flash/psram"},
+		{ChipESP32S2, 45, "strap"},
+		{ChipESP32S2, 43, "uart0"},
+		{ChipESP32C3, 12, "flash"},
+		{ChipESP32C3, 2, "strap"},
+		{ChipESP32C3, 18, "usb-jtag"},
+		{ChipESP32C3, 20, "uart0"},
+		{ChipESP32C3, 11, "vdd-spi"},
+	}
+	for _, c := range cases {
+		mc, _ := newRecordingConn()
+		f := flasherFor(c.chip, mc)
+		reserved, reason := f.GPIOReserved(c.pin)
+		if !reserved || reason != c.want {
+			t.Errorf("%s pin %d: GPIOReserved = (%v, %q), want (true, %q)", c.chip, c.pin, reserved, reason, c.want)
+		}
+	}
+}
+
+func TestGPIOReservedUnreservedPin(t *testing.T) {
+	mc, _ := newRecordingConn()
+	f := flasherFor(ChipESP32C3, mc)
+	if reserved, reason := f.GPIOReserved(5); reserved {
+		t.Errorf("C3 pin 5: GPIOReserved = (true, %q), want (false, \"\")", reason)
+	}
+}
+
+// --- Negative pins are rejected on every entry point ---
+
+func TestNegativePinErrorsOnAllMethods(t *testing.T) {
+	mc, _ := newRecordingConn()
+	f := flasherFor(ChipESP32, mc)
+
+	if err := f.SetGPIO(-1, true); err == nil {
+		t.Error("SetGPIO: expected error for negative pin")
+	}
+	if _, err := f.ReadGPIO(-1); err == nil {
+		t.Error("ReadGPIO: expected error for negative pin")
+	}
+	if err := f.ReleaseGPIO(-1); err == nil {
+		t.Error("ReleaseGPIO: expected error for negative pin")
+	}
+	if reserved, reason := f.GPIOReserved(-1); !reserved || reason != "nonexistent" {
+		t.Errorf("GPIOReserved(-1) = (%v, %q), want (true, \"nonexistent\")", reserved, reason)
+	}
+}
+
+// --- readReg/writeReg errors propagate, wrapped, from every method ---
+
+func TestReadGPIOReadRegError(t *testing.T) {
+	mc := &mockConnection{
+		readRegFunc: func(addr uint32) (uint32, error) {
+			return 0, errors.New("port closed")
+		},
+	}
+	f := flasherFor(ChipESP32, mc)
+
+	if _, err := f.ReadGPIO(16); err == nil {
+		t.Error("ReadGPIO: expected wrapped error, got nil")
+	}
+}
+
+func TestReadGPIOWriteRegError(t *testing.T) {
+	mc := &mockConnection{
+		readRegFunc: func(addr uint32) (uint32, error) {
+			return 0, nil
+		},
+		writeRegFunc: func(addr, value, mask, delayUS uint32) error {
+			return errors.New("port closed")
+		},
+	}
+	f := flasherFor(ChipESP32, mc)
+
+	if _, err := f.ReadGPIO(16); err == nil {
+		t.Error("ReadGPIO: expected wrapped error, got nil")
+	}
+}
+
+// TestReadGPIODisableOutputWriteRegError fails the second writeReg call
+// (ENABLE_W1TC, disabling the output driver) exercising that error-wrapping
+// branch specifically, distinct from the IO_MUX write and IN read paths.
+func TestReadGPIODisableOutputWriteRegError(t *testing.T) {
+	writes := 0
+	mc := &mockConnection{
+		readRegFunc: func(addr uint32) (uint32, error) {
+			return 0, nil
+		},
+		writeRegFunc: func(addr, value, mask, delayUS uint32) error {
+			writes++
+			if writes == 2 {
+				return errors.New("port closed")
+			}
+			return nil
+		},
+	}
+	f := flasherFor(ChipESP32, mc)
+
+	if _, err := f.ReadGPIO(16); err == nil {
+		t.Error("ReadGPIO: expected wrapped error for disable-output write failure, got nil")
+	}
+}
+
+// TestReadGPIOReadInRegError fails the second readReg call (the final IN
+// read), distinct from the first readReg call (IO_MUX read).
+func TestReadGPIOReadInRegError(t *testing.T) {
+	reads := 0
+	mc := &mockConnection{
+		readRegFunc: func(addr uint32) (uint32, error) {
+			reads++
+			if reads == 2 {
+				return 0, errors.New("port closed")
+			}
+			return 0, nil
+		},
+	}
+	f := flasherFor(ChipESP32, mc)
+
+	if _, err := f.ReadGPIO(16); err == nil {
+		t.Error("ReadGPIO: expected wrapped error for IN read failure, got nil")
+	}
+}
+
+func TestSetGPIOReadRegError(t *testing.T) {
+	mc := &mockConnection{
+		readRegFunc: func(addr uint32) (uint32, error) {
+			return 0, errors.New("port closed")
+		},
+	}
+	f := flasherFor(ChipESP32, mc)
+
+	if err := f.SetGPIO(16, true); err == nil {
+		t.Error("SetGPIO: expected wrapped error, got nil")
+	}
+}
+
+func TestSetGPIOWriteRegError(t *testing.T) {
+	mc := &mockConnection{
+		readRegFunc: func(addr uint32) (uint32, error) {
+			return 0, nil
+		},
+		writeRegFunc: func(addr, value, mask, delayUS uint32) error {
+			return errors.New("port closed")
+		},
+	}
+	f := flasherFor(ChipESP32, mc)
+
+	if err := f.SetGPIO(16, true); err == nil {
+		t.Error("SetGPIO: expected wrapped error, got nil")
+	}
+}
+
+// TestSetGPIOWriteRegErrorAtEachStep fails writeReg on the Nth write call to
+// exercise every writeReg error-wrapping branch inside SetGPIO (IO_MUX,
+// OUT_SEL, OUT level, and enable).
+func TestSetGPIOWriteRegErrorAtEachStep(t *testing.T) {
+	for _, failAt := range []int{1, 2, 3, 4} {
+		writes := 0
+		mc := &mockConnection{
+			readRegFunc: func(addr uint32) (uint32, error) {
+				return 0, nil
+			},
+			writeRegFunc: func(addr, value, mask, delayUS uint32) error {
+				writes++
+				if writes == failAt {
+					return errors.New("port closed")
+				}
+				return nil
+			},
+		}
+		f := flasherFor(ChipESP32, mc)
+
+		if err := f.SetGPIO(16, true); err == nil {
+			t.Errorf("SetGPIO: expected error when write #%d fails, got nil", failAt)
+		}
+	}
+}
+
+// TestSetGPIOWriteRegErrorClearOUT fails the third writeReg call (clear OUT)
+// with level=false, exercising the OUT_W1TC error-wrapping branch.
+func TestSetGPIOWriteRegErrorClearOUT(t *testing.T) {
+	writes := 0
+	mc := &mockConnection{
+		readRegFunc: func(addr uint32) (uint32, error) {
+			return 0, nil
+		},
+		writeRegFunc: func(addr, value, mask, delayUS uint32) error {
+			writes++
+			if writes == 3 {
+				return errors.New("port closed")
+			}
+			return nil
+		},
+	}
+	f := flasherFor(ChipESP32, mc)
+
+	if err := f.SetGPIO(16, false); err == nil {
+		t.Error("SetGPIO: expected wrapped error for clear-OUT write failure, got nil")
+	}
+}
+
+// TestSetGPIOReadOutSelRegError fails the OUT_SEL readReg (second readReg
+// call) specifically.
+func TestSetGPIOReadOutSelRegError(t *testing.T) {
+	reads := 0
+	mc := &mockConnection{
+		readRegFunc: func(addr uint32) (uint32, error) {
+			reads++
+			if reads == 2 {
+				return 0, errors.New("port closed")
+			}
+			return 0, nil
+		},
+	}
+	f := flasherFor(ChipESP32, mc)
+
+	if err := f.SetGPIO(16, true); err == nil {
+		t.Error("SetGPIO: expected wrapped error for OUT_SEL read failure, got nil")
+	}
+}
+
+func TestReleaseGPIOWriteRegError(t *testing.T) {
+	mc := &mockConnection{
+		readRegFunc: func(addr uint32) (uint32, error) {
+			return 0, nil
+		},
+		writeRegFunc: func(addr, value, mask, delayUS uint32) error {
+			return errors.New("port closed")
+		},
+	}
+	f := flasherFor(ChipESP32, mc)
+
+	if err := f.ReleaseGPIO(16); err == nil {
+		t.Error("ReleaseGPIO: expected wrapped error, got nil")
+	}
+}
+
+// TestReleaseGPIOWriteIOMuxRegError fails the second writeReg call (the
+// final IO_MUX write restoring FUN_IE), distinct from the first writeReg
+// call (ENABLE_W1TC).
+func TestReleaseGPIOWriteIOMuxRegError(t *testing.T) {
+	writes := 0
+	mc := &mockConnection{
+		readRegFunc: func(addr uint32) (uint32, error) {
+			return 0, nil
+		},
+		writeRegFunc: func(addr, value, mask, delayUS uint32) error {
+			writes++
+			if writes == 2 {
+				return errors.New("port closed")
+			}
+			return nil
+		},
+	}
+	f := flasherFor(ChipESP32, mc)
+
+	if err := f.ReleaseGPIO(16); err == nil {
+		t.Error("ReleaseGPIO: expected wrapped error for final IO_MUX write failure, got nil")
+	}
+}
+
+func TestReleaseGPIOReadRegError(t *testing.T) {
+	calls := 0
+	mc := &mockConnection{
+		readRegFunc: func(addr uint32) (uint32, error) {
+			calls++
+			return 0, errors.New("port closed")
+		},
+	}
+	f := flasherFor(ChipESP32, mc)
+
+	if err := f.ReleaseGPIO(16); err == nil {
+		t.Error("ReleaseGPIO: expected wrapped error, got nil")
+	}
+	if calls == 0 {
+		t.Error("expected readReg (IO_MUX) to be called before ReleaseGPIO returns")
+	}
+}
+
+// --- Unsupported chip ---
+
+func TestGPIOUnsupportedChip(t *testing.T) {
+	mc, _ := newRecordingConn()
+	f := flasherFor(ChipESP8266, mc)
+
+	if err := f.SetGPIO(2, true); err == nil {
+		t.Error("SetGPIO: expected error for unsupported chip")
+	}
+	if _, err := f.ReadGPIO(2); err == nil {
+		t.Error("ReadGPIO: expected error for unsupported chip")
+	}
+	if err := f.ReleaseGPIO(2); err == nil {
+		t.Error("ReleaseGPIO: expected error for unsupported chip")
+	}
+	if reserved, reason := f.GPIOReserved(2); !reserved || reason == "" {
+		t.Errorf("GPIOReserved = (%v, %q), want (true, non-empty)", reserved, reason)
+	}
+}
+
+// --- ESP32-S3, pin 2: sentinel 256, PIN_FUNC_GPIO=1, low-word pin ---
+
+const (
+	s3Pin2IOMux  = 0x60009000 + 0x0c
+	s3Pin2OutSel = 0x60004554 + 4*2
+)
+
+func TestSetGPIOS3Low(t *testing.T) {
+	mc, ops := newRecordingConn()
+	f := flasherFor(ChipESP32S3, mc)
+
+	if err := f.SetGPIO(2, true); err != nil {
+		t.Fatalf("SetGPIO: %v", err)
+	}
+	assertOps(t, *ops, []regOp{
+		{"r", s3Pin2IOMux, 0},
+		{"w", s3Pin2IOMux, 1 << 12},
+		{"r", s3Pin2OutSel, 0},
+		{"w", s3Pin2OutSel, 256},
+		{"w", 0x60004008, 1 << 2}, // OUT_W1TS
+		{"w", 0x60004024, 1 << 2}, // ENABLE_W1TS
+	})
+}
+
+func TestSetGPIOS3High(t *testing.T) {
+	mc, ops := newRecordingConn()
+	f := flasherFor(ChipESP32S3, mc)
+
+	if err := f.SetGPIO(2, false); err != nil {
+		t.Fatalf("SetGPIO: %v", err)
+	}
+	assertOps(t, *ops, []regOp{
+		{"r", s3Pin2IOMux, 0},
+		{"w", s3Pin2IOMux, 1 << 12},
+		{"r", s3Pin2OutSel, 0},
+		{"w", s3Pin2OutSel, 256},
+		{"w", 0x6000400C, 1 << 2}, // OUT_W1TC
+		{"w", 0x60004024, 1 << 2}, // ENABLE_W1TS
+	})
+}
+
+// --- ESP32-S3, pin 38: high-word regs (OUT1/ENABLE1/IN1), PIN_FUNC_GPIO=1 ---
+
+const (
+	s3Pin38IOMux  = 0x60009000 + 0x9c
+	s3Pin38OutSel = 0x60004554 + 4*38
+)
+
+func TestSetGPIOS3HighWordPin(t *testing.T) {
+	mc, ops := newRecordingConn()
+	f := flasherFor(ChipESP32S3, mc)
+
+	if err := f.SetGPIO(38, true); err != nil {
+		t.Fatalf("SetGPIO: %v", err)
+	}
+	assertOps(t, *ops, []regOp{
+		{"r", s3Pin38IOMux, 0},
+		{"w", s3Pin38IOMux, 1 << 12},
+		{"r", s3Pin38OutSel, 0},
+		{"w", s3Pin38OutSel, 256},
+		{"w", 0x60004014, 1 << 6}, // OUT1_W1TS, bit = 38-32
+		{"w", 0x60004030, 1 << 6}, // ENABLE1_W1TS
+	})
+}
+
+func TestReadGPIOS3Low(t *testing.T) {
+	mc, ops := newRecordingConn()
+	f := flasherFor(ChipESP32S3, mc)
+
+	if _, err := f.ReadGPIO(2); err != nil {
+		t.Fatalf("ReadGPIO: %v", err)
+	}
+	assertOps(t, *ops, []regOp{
+		{"r", s3Pin2IOMux, 0},
+		{"w", s3Pin2IOMux, (1 << 12) | ioMuxFunIEBit},
+		{"w", 0x60004028, 1 << 2}, // ENABLE_W1TC
+		{"r", 0x6000403C, 0},      // IN
+	})
+}
+
+func TestReadGPIOS3HighWordPin(t *testing.T) {
+	mc, ops := newRecordingConn()
+	f := flasherFor(ChipESP32S3, mc)
+
+	if _, err := f.ReadGPIO(38); err != nil {
+		t.Fatalf("ReadGPIO: %v", err)
+	}
+	assertOps(t, *ops, []regOp{
+		{"r", s3Pin38IOMux, 0},
+		{"w", s3Pin38IOMux, (1 << 12) | ioMuxFunIEBit},
+		{"w", 0x60004034, 1 << 6}, // ENABLE1_W1TC, bit = 38-32
+		{"r", 0x60004040, 0},      // IN1
+	})
+}
+
+func TestReleaseGPIOS3HighWordPin(t *testing.T) {
+	mc, ops := newRecordingConn()
+	f := flasherFor(ChipESP32S3, mc)
+
+	if err := f.ReleaseGPIO(38); err != nil {
+		t.Fatalf("ReleaseGPIO: %v", err)
+	}
+	assertOps(t, *ops, []regOp{
+		{"w", 0x60004034, 1 << 6}, // ENABLE1_W1TC
+		{"r", s3Pin38IOMux, 0},
+		{"w", s3Pin38IOMux, ioMuxFunIEBit},
+	})
+}
+
+// --- ESP32-S3 IO_MUX offsets are linear across the 22-25 gap ---
+
+func TestS3IOMuxLinearOffsets(t *testing.T) {
+	cases := []struct {
+		pin      int
+		wantAddr uint32
+	}{
+		{2, 0x60009000 + 0x0c},
+		{38, 0x60009000 + 0x9c},
+	}
+	for _, c := range cases {
+		mc, ops := newRecordingConn()
+		f := flasherFor(ChipESP32S3, mc)
+		if _, err := f.ReadGPIO(c.pin); err != nil {
+			t.Fatalf("pin %d: ReadGPIO: %v", c.pin, err)
+		}
+		if (*ops)[0].addr != c.wantAddr {
+			t.Errorf("GPIO%d IO_MUX addr = %#x, want %#x", c.pin, (*ops)[0].addr, c.wantAddr)
+		}
+	}
+}
+
+// --- ESP32-S3 nonexistent pins 22-25 rejected on every method ---
+
+func TestS3NonexistentPinsRejected(t *testing.T) {
+	for _, pin := range []int{22, 23, 24, 25} {
+		mc, _ := newRecordingConn()
+		f := flasherFor(ChipESP32S3, mc)
+
+		if err := f.SetGPIO(pin, true); err == nil {
+			t.Errorf("pin %d: SetGPIO expected error", pin)
+		}
+		if _, err := f.ReadGPIO(pin); err == nil {
+			t.Errorf("pin %d: ReadGPIO expected error", pin)
+		}
+		if err := f.ReleaseGPIO(pin); err == nil {
+			t.Errorf("pin %d: ReleaseGPIO expected error", pin)
+		}
+		reserved, reason := f.GPIOReserved(pin)
+		if !reserved || reason != "nonexistent" {
+			t.Errorf("pin %d: GPIOReserved = (%v, %q), want (true, \"nonexistent\")", pin, reserved, reason)
+		}
+	}
+}
+
+// --- ESP32-S3 GPIOReserved classifications ---
+
+func TestGPIOReservedClassificationsS3(t *testing.T) {
+	cases := []struct {
+		pin  int
+		want string
+	}{
+		{26, "flash/psram"},
+		{33, "flash/psram"},
+		{45, "strap"},
+		{19, "usb-jtag"},
+		{43, "uart0"},
+		{47, "differential-clock octal PSRAM"},
+		{48, "differential-clock octal PSRAM"},
+	}
+	for _, c := range cases {
+		mc, _ := newRecordingConn()
+		f := flasherFor(ChipESP32S3, mc)
+		reserved, reason := f.GPIOReserved(c.pin)
+		if !reserved || reason != c.want {
+			t.Errorf("S3 pin %d: GPIOReserved = (%v, %q), want (true, %q)", c.pin, reserved, reason, c.want)
+		}
+	}
+}
+
+func TestGPIOReservedJTAGNotReservedS3(t *testing.T) {
+	mc, _ := newRecordingConn()
+	f := flasherFor(ChipESP32S3, mc)
+	if reserved, reason := f.GPIOReserved(40); reserved {
+		t.Errorf("S3 pin 40 (JTAG): GPIOReserved = (true, %q), want (false, \"\")", reason)
+	}
+}


### PR DESCRIPTION
- ReadGPIO/SetGPIO/ReleaseGPIO/GPIOReserved over the bootloader's raw
  register peek/poke, using W1TS/W1TC for atomic bit set/clear and RMW
  only for IO_MUX and GPIO-matrix OUT_SEL config to preserve unrelated
  fields
- per-chip register maps reject nonexistent pins, refuse driving
  input-only pins, and classify flash/strap/UART0/USB-JTAG reservations
  for the caller to gate
